### PR TITLE
Pike

### DIFF
--- a/manifests/cinder/api.pp
+++ b/manifests/cinder/api.pp
@@ -1,26 +1,7 @@
 # Installs and configures the cinder API
 class ntnuopenstack::cinder::api {
-  $region = hiera('ntnuopenstack::region')
   $confhaproxy = hiera('ntnuopenstack::haproxy::configure::backend', true)
-
-  $keystone_password = hiera('ntnuopenstack::cinder::keystone::password')
-
-  # Determine the keystone endpoint
-  $admin_endpoint = hiera('ntnuopenstack::endpoint::admin', undef)
-  $public_endpoint = hiera('ntnuopenstack::endpoint::public', undef)
-  $keystone_public_ip = hiera('profile::api::keystone::public::ip', false)
   $keystone_admin_ip = hiera('profile::api::keystone::admin::ip', false)
-  $keystone_admin  = pick($admin_endpoint, "http://${keystone_admin_ip}")
-  $keystone_public = pick($public_endpoint, "http://${keystone_public_ip}")
-
-  # Retrieve addresses for the memcached servers, either the old IP or the new
-  # list of hosts.
-  $memcached_ip = hiera('profile::memcache::ip', undef)
-  $memcache_servers = hiera_array('profile::memcache::servers', undef)
-  $memcache_servers_real = pick($memcache_servers, [$memcached_ip])
-  $memcache = $memcache_servers_real.map | $server | {
-    "${server}:11211"
-  }
 
   include ::cinder::db::sync
   require ::ntnuopenstack::repo
@@ -37,19 +18,8 @@ class ntnuopenstack::cinder::api {
   }
 
   class { '::cinder::api':
-    # Auth_strategy is false to prevent cinder::api from including
-    # ::cinder::keystone::authtoken.
-    auth_strategy                => false,
     enabled                      => true,
     default_volume_type          => 'Normal',
     enable_proxy_headers_parsing => $confhaproxy,
-  }
-
-  class { '::cinder::keystone::authtoken':
-    auth_url          => "${keystone_admin}:35357",
-    auth_uri          => "${keystone_public}:5000",
-    password          => $keystone_password,
-    memcached_servers => $memcache,
-    region_name       => $region,
   }
 }

--- a/manifests/keystone/endpoint.pp
+++ b/manifests/keystone/endpoint.pp
@@ -25,7 +25,6 @@ class ntnuopenstack::keystone::endpoint {
     public_url   => "${public_endpoint}:5000",
     admin_url    => "${admin_endpoint}:35357",
     internal_url => "${internal_endpoint}:5000",
-    version      => 'v3',
     region       => $region,
     require      => Class['::keystone'],
   }

--- a/manifests/keystone/ldap.pp
+++ b/manifests/keystone/ldap.pp
@@ -28,6 +28,7 @@ class ntnuopenstack::keystone::ldap {
     user_enabled_attribute => userAccountControl,
     user_enabled_mask      => 2,
     user_enabled_default   => 512,
+    group_ad_nesting       => true,
     group_tree_dn          => $ldap_group_tree_dn,
     group_filter           => $ldap_group_filter,
     group_objectclass      => group,
@@ -40,7 +41,6 @@ class ntnuopenstack::keystone::ldap {
 
   keystone_domain_config {
     "${ldap_name}::identity/list_limit": value   => '100';
-    "${ldap_name}::ldap/group_ad_nesting": value => true;
   }
 
   keystone_domain { $ldap_name:

--- a/manifests/nova/compute.pp
+++ b/manifests/nova/compute.pp
@@ -24,8 +24,6 @@ class ntnuopenstack::nova::compute {
     $protocol = 'http'
   }
 
-  nova_config { 'DEFAULT/default_floating_pool': value => 'public' }
-
   class { '::nova::compute':
     enabled                          => true,
     vnc_enabled                      => true,

--- a/manifests/nova/endpoint/api.pp
+++ b/manifests/nova/endpoint/api.pp
@@ -20,12 +20,9 @@ class ntnuopenstack::nova::endpoint::api {
 
   class { '::nova::keystone::auth':
     password        => $nova_password,
-    public_url      => "${nova_public}:8774/v2/%(tenant_id)s",
-    internal_url    => "${nova_internal}:8774/v2/%(tenant_id)s",
-    admin_url       => "${nova_admin}:8774/v2/%(tenant_id)s",
-    public_url_v3   => "${nova_public}:8774/v3",
-    internal_url_v3 => "${nova_internal}:8774/v3",
-    admin_url_v3    => "${nova_admin}:8774/v3",
+    public_url      => "${nova_public}:8774/v2.1",
+    internal_url    => "${nova_internal}:8774/v2.1",
+    admin_url       => "${nova_admin}:8774/v2.1",
     region          => $region,
   }
 }

--- a/manifests/nova/neutron.pp
+++ b/manifests/nova/neutron.pp
@@ -11,9 +11,13 @@ class ntnuopenstack::nova::neutron {
   $neutron_admin_ip = hiera('profile::api::neutron::admin::ip', '127.0.0.1')
   $neutron_internal = pick($internal_endpoint, "http://${neutron_admin_ip}")
 
+  $default_floating_pool = hiera('ntnuopenstack::neutron::default::floatingpool',
+      'ntnu-internal')
+
   require ::ntnuopenstack::repo
 
   class { '::nova::network::neutron':
+    default_floating_pool => $default_floating_pool,
     neutron_region_name   => $region,
     neutron_password      => $neutron_password,
     neutron_url           => "${neutron_internal}:9696",

--- a/manifests/nova/services.pp
+++ b/manifests/nova/services.pp
@@ -7,7 +7,6 @@ class ntnuopenstack::nova::services {
 
   class { [
     '::nova::scheduler',
-    '::nova::cert',
     '::nova::consoleauth',
     '::nova::conductor'
   ]:


### PR DESCRIPTION
First stable pike deployment

New hiera-keys:
 - cinder::keystone::authtoken::auth_url: "%{alias('ntnuopenstack::keystone::auth::url')}"
 - cinder::keystone::authtoken::auth_uri: "%{alias('ntnuopenstack::keystone::auth::uri')}"
 - cinder::keystone::authtoken::memcached_servers: "%{alias('ntnuopenstack::keystone::memcached::servers')}"
 - cinder::keystone::authtoken::password: "%{lookup('ntnuopenstack::cinder::keystone::password')}"
 - cinder::keystone::authtoken::region_name: "%{lookup('ntnuopenstack::region')}"
 - ntnuopenstack::keystone::memcached::servers:
 -- '1.2.3.4:11411'