### PR TITLE
Queens

### DIFF
--- a/manifests/heat/endpoint.pp
+++ b/manifests/heat/endpoint.pp
@@ -15,13 +15,13 @@ class ntnuopenstack::heat::endpoint {
   $heat_public    = pick($public_endpoint, "http://${heat_public_ip}")
 
   # Other settings
-  $mysql_pass = hiera('ntnuopenstack::heat::mysql::password')
+  $heat_password = hiera('ntnuopenstack::heat::keystone::password')
   $region = hiera('ntnuopenstack::region')
 
   require ::ntnuopenstack::repo
 
   class  { '::heat::keystone::auth':
-    password     => $mysql_pass,
+    password     => $heat_password,
     public_url   => "${heat_public}:8004/v1/%(tenant_id)s",
     internal_url => "${heat_internal}:8004/v1/%(tenant_id)s",
     admin_url    => "${heat_admin}:8004/v1/%(tenant_id)s",
@@ -29,7 +29,7 @@ class ntnuopenstack::heat::endpoint {
   }
 
   class { '::heat::keystone::auth_cfn':
-    password     => $mysql_pass,
+    password     => $heat_password,
     service_name => 'heat-cfn',
     region       => $region,
     public_url   => "${heat_public}:8000/v1",

--- a/manifests/horizon.pp
+++ b/manifests/horizon.pp
@@ -77,10 +77,10 @@ class ntnuopenstack::horizon {
     keystone_default_domain        => $ldap_name,
     keystone_multidomain_support   => true,
     keystone_url                   => $keystone_url,
-    keystone_domain_choices        => {
-      {'name': 'default', 'display': 'The default domain'},
-      {'name': $ldap_name, 'display': $description},
-    },
+    keystone_domain_choices        => [
+      {'name' => 'default', 'display' => 'The default domain'},
+      {'name' => $ldap_name, 'display' => $description},
+    ],
     neutron_options                => {
       enable_firewall => true,
       enable_lb       => true,

--- a/manifests/horizon.pp
+++ b/manifests/horizon.pp
@@ -71,6 +71,8 @@ class ntnuopenstack::horizon {
     $memcache = {}
   }
 
+  horizon::dashboard { 'heat': }
+
   class { '::horizon':
     allowed_hosts                  => [$::fqdn, $server_name],
     enable_secure_proxy_ssl_header => $haproxy,
@@ -78,8 +80,8 @@ class ntnuopenstack::horizon {
     keystone_multidomain_support   => true,
     keystone_url                   => $keystone_url,
     keystone_domain_choices        => [
-      {'name' => 'default', 'display' => 'Openstack accounts'},
       {'name' => $ldap_name, 'display' => $description},
+      {'name' => 'default',  'display' => 'Openstack accounts'},
     ],
     neutron_options                => {
       enable_firewall => true,

--- a/manifests/horizon.pp
+++ b/manifests/horizon.pp
@@ -78,7 +78,7 @@ class ntnuopenstack::horizon {
     keystone_multidomain_support   => true,
     keystone_url                   => $keystone_url,
     keystone_domain_choices        => [
-      {'name' => 'default', 'display' => 'The default domain'},
+      {'name' => 'default', 'display' => 'Openstack accounts'},
       {'name' => $ldap_name, 'display' => $description},
     ],
     neutron_options                => {

--- a/manifests/horizon.pp
+++ b/manifests/horizon.pp
@@ -79,9 +79,9 @@ class ntnuopenstack::horizon {
       enable_firewall => true,
       enable_lb       => true,
     },
-    #instance_options               => {
-    #  create_volume => false,
-    #},
+    instance_options               => {
+      create_volume => false,
+    },
     secret_key                     => $django_secret,
     server_aliases                 => [$::fqdn, $server_name],
     servername                     => $server_name,

--- a/manifests/horizon.pp
+++ b/manifests/horizon.pp
@@ -17,6 +17,8 @@ class ntnuopenstack::horizon {
   $server_name = hiera('ntnuopenstack::horizon::server_name')
   $django_secret = hiera('ntnuopenstack::horizon::django_secret')
   $ldap_name = hiera('ntnuopenstack::keystone::ldap_backend::name')
+  $description = hiera('ntnuopenstack::horizon::ldap::description',
+      "${ldap_name} accounts")
 
   # Try to retrieve memcache addresses.
   $memcache_servers = hiera_array('profile::memcache::servers', false)
@@ -75,6 +77,10 @@ class ntnuopenstack::horizon {
     keystone_default_domain        => $ldap_name,
     keystone_multidomain_support   => true,
     keystone_url                   => $keystone_url,
+    keystone_domain_choices        => {
+      {'name': 'default', 'display': 'The default domain'},
+      {'name': $ldap_name, 'display': $description},
+    },
     neutron_options                => {
       enable_firewall => true,
       enable_lb       => true,

--- a/manifests/neutron/agents.pp
+++ b/manifests/neutron/agents.pp
@@ -12,7 +12,7 @@ class ntnuopenstack::neutron::agents {
 
   class { '::neutron::agents::metadata':
     shared_secret => $nova_metadata_secret,
-    metadata_ip   => pick($adminlb_ip, $admin_ip),
+    metadata_host => pick($adminlb_ip, $admin_ip),
     enabled       => true,
   }
 

--- a/manifests/nova/compute.pp
+++ b/manifests/nova/compute.pp
@@ -36,6 +36,7 @@ class ntnuopenstack::nova::compute {
 
   user { 'nova':
     shell => '/bin/bash',
+    home  => '/var/lib/nova',
   }
 
   class { '::nova::compute::rbd':


### PR DESCRIPTION
This release contains changes required for the Openstack Queens update.

There are also some minor changes:
 - Heat gets a servicepassword
 - We add a drop-down on the horizon login page to select domain
 - We change the default for "create volume" when booting an instance to false

Some hiera changes:
 - ntnuopenstack::heat::keystone::password - The service-password for heat
 - heat::keystone::authtoken::password: "%{lookup('ntnuopenstack::heat::keystone::password')}"
