### PR TITLE
Enable AggregateImagePropertiesIsolation filter

### DIFF
--- a/manifests/nova/services.pp
+++ b/manifests/nova/services.pp
@@ -5,6 +5,22 @@ class ntnuopenstack::nova::services {
   contain ::ntnuopenstack::nova::neutron
   contain ::ntnuopenstack::nova::vncproxy
 
+  $default_filters = [
+    'AggregateImagePropertiesIsolation',
+    'RetryFilter',
+    'AvailabilityZoneFilter',
+    'ComputeFilter',
+    'ComputeCapabilitiesFilter',
+    'ImagePropertiesFilter',
+    'ServerGroupAntiAffinityFilter',
+    'ServerGroupAffinityFilter'
+  ]
+
+  $default_filters_real = lookup('ntnuopenstack::nova::default_scheduling_filters', {
+    'default_value' => $default_filters,
+    'value_type'    => Array[String],
+  })
+
   $discover_interval = lookup('ntnuopenstack::nova::discover_hosts_interval', {
     'default_value' => 3600,
     'value_type'    => Integer,
@@ -19,5 +35,9 @@ class ntnuopenstack::nova::services {
 
   class { '::nova::scheduler':
     discover_hosts_in_cells_interval => $discover_interval,
+  }
+
+  class { '::nova::scheduler::filter':
+    scheduler_default_filters => $default_filters_real,
   }
 }


### PR DESCRIPTION
Adds the AggregateImagePropertiesIsolation filter to the list of enabled filters in nova-scheduler. The other listed filters are the default filters from the Queens release