### PR TITLE
Add option to use the neutron BGP agent

### DIFF
--- a/manifests/neutron/agents.pp
+++ b/manifests/neutron/agents.pp
@@ -10,6 +10,10 @@ class ntnuopenstack::neutron::agents {
   $neutron_vrrp_pass = lookup('ntnuopenstack::neutron::vrrp_pass', String)
   $metadata_secret = lookup('ntnuopenstack::nova::sharedmetadataproxysecret',
                             String)
+  $bgp_routerID = lookup('ntnuopenstack::neutron::bgp::router::id', {
+    'value_type'    => Stdlib::IP::Address,
+    'default_value' => '0.0.0.0',
+  })
 
   require ::ntnuopenstack::neutron::base
   require ::ntnuopenstack::neutron::firewall::l3agent
@@ -29,5 +33,11 @@ class ntnuopenstack::neutron::agents {
     ha_enabled            => true,
     ha_vrrp_auth_password => $neutron_vrrp_pass,
     extensions            => 'fwaas_v2,port_forwarding',
+  }
+
+  if($bgp_routerID != '0.0.0.0') {
+    ::neutron::agents::bgp_dragent {
+      bgp_router_id => $bgp_routerID,
+    }
   }
 }

--- a/manifests/neutron/agents.pp
+++ b/manifests/neutron/agents.pp
@@ -10,7 +10,7 @@ class ntnuopenstack::neutron::agents {
   $neutron_vrrp_pass = lookup('ntnuopenstack::neutron::vrrp_pass', String)
   $metadata_secret = lookup('ntnuopenstack::nova::sharedmetadataproxysecret',
                             String)
-  $bgp_routerID = lookup('ntnuopenstack::neutron::bgp::router::id', {
+  $bgp_router_id = lookup('ntnuopenstack::neutron::bgp::router::id', {
     'value_type'    => Stdlib::IP::Address,
     'default_value' => '0.0.0.0',
   })
@@ -35,9 +35,9 @@ class ntnuopenstack::neutron::agents {
     extensions            => 'fwaas_v2,port_forwarding',
   }
 
-  if($bgp_routerID != '0.0.0.0') {
-    ::neutron::agents::bgp_dragent {
-      bgp_router_id => $bgp_routerID,
+  if($bgp_router_id != '0.0.0.0') {
+    class { '::neutron::agents::bgp_dragent':
+      bgp_router_id => $bgp_router_id,
     }
   }
 }


### PR DESCRIPTION
If a BGP router-id is listed in the node-file in hiera for a neutronnet-node, the BGP agent will be installed. This can be used to announce tenant-networks over BGP.

`ntnuopenstack::neutron::bgp::router::id` - BGP Router ID