### PR TITLE
Rocky

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -35,6 +35,7 @@ ntnuopenstack::neutron::endpoint::public: "%{alias('ntnuopenstack::endpoint::pub
 ntnuopenstack::neutron::metadata::ip: "%{alias('ntnuopenstack::endpoint::admin::ipv4')}"
 ntnuopenstack::neutron::mysql::ip: "%{alias('ntnuopenstack::endpoint::admin::ipv4')}"
 
+ntnuopenstack::nova::db::sync: "%{alias('ntnuopenstack::db::sync')}"
 ntnuopenstack::nova::endpoint::admin: "%{alias('ntnuopenstack::endpoint::admin')}"
 ntnuopenstack::nova::endpoint::internal: "%{alias('ntnuopenstack::endpoint::internal')}"
 ntnuopenstack::nova::endpoint::public: "%{alias('ntnuopenstack::endpoint::public')}"

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -27,6 +27,7 @@ ntnuopenstack::keystone::endpoint::internal: "%{alias('ntnuopenstack::endpoint::
 ntnuopenstack::keystone::endpoint::public: "%{alias('ntnuopenstack::endpoint::public')}"
 ntnuopenstack::keystone::mysql::ip: "%{alias('ntnuopenstack::endpoint::admin::ipv4')}"
 
+ntnuopenstack::neutron::db::sync: "%{alias('ntnuopenstack::db::sync')}"
 ntnuopenstack::neutron::dns: "%{alias('profile::dns::resolvers')}"
 ntnuopenstack::neutron::endpoint::admin: "%{alias('ntnuopenstack::endpoint::admin')}"
 ntnuopenstack::neutron::endpoint::internal: "%{alias('ntnuopenstack::endpoint::internal')}"

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,9 +1,9 @@
 ---
 ntnuopenstack::db::sync: false 
 
+ntnuopenstack::cinder::db::sync: "%{alias('ntnuopenstack::db::sync')}"
 ntnuopenstack::cinder::endpoint::admin: "%{alias('ntnuopenstack::endpoint::admin')}"
 ntnuopenstack::cinder::endpoint::internal: "%{alias('ntnuopenstack::endpoint::internal')}"
-ntnuopenstack::cinder::db::sync: "%{alias('ntnuopenstack::db::sync')}"
 ntnuopenstack::cinder::endpoint::public: "%{alias('ntnuopenstack::endpoint::public')}"
 ntnuopenstack::cinder::mysql::ip: "%{alias('ntnuopenstack::endpoint::admin::ipv4')}"
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -13,6 +13,7 @@ ntnuopenstack::glance::endpoint::internal: "%{alias('ntnuopenstack::endpoint::in
 ntnuopenstack::glance::endpoint::public: "%{alias('ntnuopenstack::endpoint::public')}"
 ntnuopenstack::glance::mysql::ip: "%{alias('ntnuopenstack::endpoint::admin::ipv4')}"
 
+ntnuopenstack::heat::db::sync: "%{alias('ntnuopenstack::db::sync')}"
 ntnuopenstack::heat::endpoint::admin: "%{alias('ntnuopenstack::endpoint::admin')}"
 ntnuopenstack::heat::endpoint::internal: "%{alias('ntnuopenstack::endpoint::internal')}"
 ntnuopenstack::heat::endpoint::public: "%{alias('ntnuopenstack::endpoint::public')}"

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -19,6 +19,7 @@ ntnuopenstack::heat::endpoint::internal: "%{alias('ntnuopenstack::endpoint::inte
 ntnuopenstack::heat::endpoint::public: "%{alias('ntnuopenstack::endpoint::public')}"
 ntnuopenstack::heat::mysql::ip: "%{alias('ntnuopenstack::endpoint::admin::ipv4')}"
 
+ntnuopenstack::keystone::db::sync: "%{alias('ntnuopenstack::db::sync')}"
 ntnuopenstack::keystone::auth::url: "%{lookup('ntnuopenstack::endpoint::admin')}:35357"
 ntnuopenstack::keystone::auth::uri: "%{lookup('ntnuopenstack::endpoint::internal')}:5000/"
 ntnuopenstack::keystone::endpoint::admin: "%{alias('ntnuopenstack::endpoint::admin')}"

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,9 +1,12 @@
 ---
+ntnuopenstack::db::sync: false 
+
 ntnuopenstack::cinder::endpoint::admin: "%{alias('ntnuopenstack::endpoint::admin')}"
 ntnuopenstack::cinder::endpoint::internal: "%{alias('ntnuopenstack::endpoint::internal')}"
 ntnuopenstack::cinder::endpoint::public: "%{alias('ntnuopenstack::endpoint::public')}"
 ntnuopenstack::cinder::mysql::ip: "%{alias('ntnuopenstack::endpoint::admin::ipv4')}"
 
+ntnuopenstack::glance::db::sync: "%{alias('ntnuopenstack::db::sync')}"
 ntnuopenstack::glance::endpoint::admin: "%{alias('ntnuopenstack::endpoint::admin')}"
 ntnuopenstack::glance::endpoint::internal: "%{alias('ntnuopenstack::endpoint::internal')}"
 ntnuopenstack::glance::endpoint::public: "%{alias('ntnuopenstack::endpoint::public')}"

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -3,6 +3,7 @@ ntnuopenstack::db::sync: false
 
 ntnuopenstack::cinder::endpoint::admin: "%{alias('ntnuopenstack::endpoint::admin')}"
 ntnuopenstack::cinder::endpoint::internal: "%{alias('ntnuopenstack::endpoint::internal')}"
+ntnuopenstack::cinder::db::sync: "%{alias('ntnuopenstack::db::sync')}"
 ntnuopenstack::cinder::endpoint::public: "%{alias('ntnuopenstack::endpoint::public')}"
 ntnuopenstack::cinder::mysql::ip: "%{alias('ntnuopenstack::endpoint::admin::ipv4')}"
 

--- a/manifests/cinder/api.pp
+++ b/manifests/cinder/api.pp
@@ -6,10 +6,6 @@ class ntnuopenstack::cinder::api {
   })
   $db_sync = lookup('ntnuopenstack::cinder::db::sync', Boolean)
 
-  if ($db_sync) {
-    include ::cinder::db::sync
-  }
-
   require ::ntnuopenstack::repo
   require ::ntnuopenstack::cinder::base
   contain ::ntnuopenstack::cinder::firewall::server
@@ -27,6 +23,7 @@ class ntnuopenstack::cinder::api {
     service_name                 => 'httpd',
     default_volume_type          => 'Normal',
     enable_proxy_headers_parsing => $confhaproxy,
+    sync_db                      => $db_sync,
   }
 
   class { '::cinder::wsgi::apache':

--- a/manifests/cinder/api.pp
+++ b/manifests/cinder/api.pp
@@ -4,8 +4,12 @@ class ntnuopenstack::cinder::api {
     'default_value' => true,
     'value_type'    => Boolean,
   })
+  $db_sync = lookup('ntnuopenstack::cinder::db::sync', Boolean)
 
-  include ::cinder::db::sync
+  if ($db_sync) {
+    include ::cinder::db::sync
+  }
+
   require ::ntnuopenstack::repo
   require ::ntnuopenstack::cinder::base
   contain ::ntnuopenstack::cinder::firewall::server

--- a/manifests/cinder/base.pp
+++ b/manifests/cinder/base.pp
@@ -3,7 +3,7 @@ class ntnuopenstack::cinder::base {
   # Determine where the database resides 
   $mysql_pass = lookup('ntnuopenstack::cinder::mysql::password', String)
   $mysql_ip = lookup('ntnuopenstack::cinder::mysql::ip', Stdlib::IP::Address)
-  $database_connection = "mysql://cinder:${mysql_pass}@${mysql_ip}/cinder"
+  $database_connection = "mysql+pymysql://cinder:${mysql_pass}@${mysql_ip}/cinder"
 
   # Credentials for the messagequeue
   $transport_url = lookup('ntnuopenstack::transport::url', String)

--- a/manifests/glance/api.pp
+++ b/manifests/glance/api.pp
@@ -4,6 +4,7 @@ class ntnuopenstack::glance::api {
   $mysql_pass= lookup('ntnuopenstack::glance::mysql::password', String)
   $mysql_ip = lookup('ntnuopenstack::glance::mysql::ip', Stdlib::IP::Address)
   $database_connection = "mysql://glance:${mysql_pass}@${mysql_ip}/glance"
+  $db_sync = lookup('ntnuopenstack::glance::db::sync', Boolean)
 
   # Openstack parameters
   $region = lookup('ntnuopenstack::region', String)
@@ -52,6 +53,7 @@ class ntnuopenstack::glance::api {
     os_region_name               => $region,
     show_image_direct_url        => true,
     show_multiple_locations      => true,
+    sync_db                      => $db_sync,
   }
 
   class { '::glance::api::authtoken':

--- a/manifests/glance/api.pp
+++ b/manifests/glance/api.pp
@@ -3,7 +3,7 @@ class ntnuopenstack::glance::api {
   # Determine where the database is
   $mysql_pass= lookup('ntnuopenstack::glance::mysql::password', String)
   $mysql_ip = lookup('ntnuopenstack::glance::mysql::ip', Stdlib::IP::Address)
-  $database_connection = "mysql://glance:${mysql_pass}@${mysql_ip}/glance"
+  $database_connection = "mysql+pymysql://glance:${mysql_pass}@${mysql_ip}/glance"
   $db_sync = lookup('ntnuopenstack::glance::db::sync', Boolean)
 
   # Openstack parameters

--- a/manifests/glance/api.pp
+++ b/manifests/glance/api.pp
@@ -10,7 +10,7 @@ class ntnuopenstack::glance::api {
   $keystone_password = lookup('ntnuopenstack::glance::keystone::password', String)
 
   # Determine where the keystone service is located.
-  $keystone_admin  = lookup('ntnuopenstack::keystone::endpoint::admin', Stdlib::Httpurl)
+  $keystone_internal = lookup('ntnuopenstack::keystone::endpoint::internal', Stdlib::Httpurl)
   $keystone_public = lookup('ntnuopenstack::keystone::endpoint::public', Stdlib::Httpurl)
 
   # Retrieve addresses for the memcached servers, either the old IP or the new
@@ -48,7 +48,7 @@ class ntnuopenstack::glance::api {
     auth_strategy                => '',
     database_connection          => $database_connection,
     enable_proxy_headers_parsing => $confhaproxy,
-    known_stores                 => ['glance.store.rbd.Store'],
+    stores                       => ['glance.store.rbd.Store'],
     os_region_name               => $region,
     registry_host                => '127.0.0.1',
     show_image_direct_url        => true,
@@ -56,11 +56,11 @@ class ntnuopenstack::glance::api {
   }
 
   class { '::glance::api::authtoken':
-    password          => $keystone_password,
-    auth_url          => "${keystone_admin}:35357",
-    auth_uri          => "${keystone_public}:5000",
-    memcached_servers => $memcache,
-    region_name       => $region,
+    password             => $keystone_password,
+    auth_url             => "${keystone_internal}:5000",
+    www_authenticate_uri => "${keystone_public}:5000",
+    memcached_servers    => $memcache,
+    region_name          => $region,
   }
 
   glance_api_config {

--- a/manifests/glance/api.pp
+++ b/manifests/glance/api.pp
@@ -50,7 +50,6 @@ class ntnuopenstack::glance::api {
     enable_proxy_headers_parsing => $confhaproxy,
     stores                       => ['glance.store.rbd.Store'],
     os_region_name               => $region,
-    registry_host                => '127.0.0.1',
     show_image_direct_url        => true,
     show_multiple_locations      => true,
   }

--- a/manifests/glance/ceph.pp
+++ b/manifests/glance/ceph.pp
@@ -19,4 +19,8 @@ class ntnuopenstack::glance::ceph {
       'allow class-read object_prefix rbd_children, allow rwx pool=images',
     inject  => true,
   }
+
+  class { '::glance::backend::rbd' :
+    rbd_store_user => 'glance',
+  }
 }

--- a/manifests/glance/firewall/haproxy/registry.pp
+++ b/manifests/glance/firewall/haproxy/registry.pp
@@ -1,7 +1,0 @@
-# Configures the firewall to accept incoming traffic to the glance registry API. 
-class ntnuopenstack::glance::firewall::haproxy::registry {
-  ::profile::baseconfig::firewall::service::infra { 'Glance-Registry':
-    protocol => 'tcp',
-    port     => 9191,
-  }
-}

--- a/manifests/glance/firewall/server/registry.pp
+++ b/manifests/glance/firewall/server/registry.pp
@@ -1,7 +1,0 @@
-# Configures the firewall to accept incoming traffic to the glance registry API. 
-class ntnuopenstack::glance::firewall::server::registry {
-  ::profile::baseconfig::firewall::service::infra { 'Glance-Registry':
-    protocol => 'tcp',
-    port     => 9191,
-  }
-}

--- a/manifests/glance/haproxy/backend.pp
+++ b/manifests/glance/haproxy/backend.pp
@@ -28,17 +28,4 @@ class ntnuopenstack::glance::haproxy::backend {
     ports             => '9292',
     options           => 'check inter 2000 rise 2 fall 5',
   }
-
-  profile::services::haproxy::tools::register { "GlanceRegistry-${::hostname}":
-    servername  => $::hostname,
-    backendname => 'bk_glance_registry',
-  }
-
-  @@haproxy::balancermember { "glance-registry-${::fqdn}":
-    listening_service => 'bk_glance_registry',
-    server_names      => $::hostname,
-    ipaddresses       => $ip,
-    ports             => '9191',
-    options           => 'check inter 2000 rise 2 fall 5',
-  }
 }

--- a/manifests/glance/haproxy/management.pp
+++ b/manifests/glance/haproxy/management.pp
@@ -1,11 +1,9 @@
-# Configures the haproxy frontend for the internal and admin glance API and the
-# glance registry
+# Configures the haproxy frontend for the internal and admin glance API
 class ntnuopenstack::glance::haproxy::management {
   require ::profile::services::haproxy
   require ::profile::services::haproxy::certs::manageapi
 
   include ::ntnuopenstack::glance::firewall::haproxy::api
-  include ::ntnuopenstack::glance::firewall::haproxy::registry
 
   $certificate = lookup('ntnuopenstack::endpoint::admin::cert', {
     'default_value' => false,
@@ -29,19 +27,6 @@ class ntnuopenstack::glance::haproxy::management {
         'tcplog',
         'tcpka',
         'httpchk',
-      ],
-    },
-  }
-
-  ::profile::services::haproxy::frontend { 'glance_registry':
-    profile   => 'management',
-    port      => 9191,
-    certfile  => $certfile,
-    mode      => 'http',
-    bkoptions => {
-      'option'  => [
-        'tcplog',
-        'tcpka',
       ],
     },
   }

--- a/manifests/glance/registry.pp
+++ b/manifests/glance/registry.pp
@@ -10,7 +10,7 @@ class ntnuopenstack::glance::registry {
   $keystone_password = lookup('ntnuopenstack::glance::keystone::password', String)
 
   # Determine where the keystone service is located.
-  $keystone_admin  = lookup('ntnuopenstack::keystone::endpoint::admin', Stdlib::Httpurl)
+  $keystone_internal = lookup('ntnuopenstack::keystone::endpoint::internal', Stdlib::Httpurl)
   $keystone_public = lookup('ntnuopenstack::keystone::endpoint::public', Stdlib::Httpurl)
 
   # Retrieve addresses for the memcached servers, either the old IP or the new
@@ -51,10 +51,10 @@ class ntnuopenstack::glance::registry {
   }
 
   class { '::glance::registry::authtoken':
-    password          => $keystone_password,
-    auth_url          => "${keystone_admin}:35357",
-    auth_uri          => "${keystone_public}:5000",
-    memcached_servers => $memcache,
-    region_name       => $region,
+    password             => $keystone_password,
+    auth_url             => "${keystone_internal}:5000",
+    www_authenticate_uri => "${keystone_public}:5000",
+    memcached_servers    => $memcache,
+    region_name          => $region,
   }
 }

--- a/manifests/glance/registry.pp
+++ b/manifests/glance/registry.pp
@@ -1,60 +1,8 @@
-# Configures glance registry and backend
+# Ensures that glance-registry is disabled and removed. It is deprecated as of
+# Queens, and will be removed at Stein.  
 class ntnuopenstack::glance::registry {
-  # Determine where the database is
-  $mysql_pass = lookup('ntnuopenstack::glance::mysql::password', String)
-  $mysql_ip = lookup('ntnuopenstack::keystone::mysql::ip', Stdlib::IP::Address)
-  $database_connection = "mysql://glance:${mysql_pass}@${mysql_ip}/glance"
-
-  # Openstack parameters
-  $region = lookup('ntnuopenstack::region', String)
-  $keystone_password = lookup('ntnuopenstack::glance::keystone::password', String)
-
-  # Determine where the keystone service is located.
-  $keystone_internal = lookup('ntnuopenstack::keystone::endpoint::internal', Stdlib::Httpurl)
-  $keystone_public = lookup('ntnuopenstack::keystone::endpoint::public', Stdlib::Httpurl)
-
-  # Retrieve addresses for the memcached servers, either the old IP or the new
-  # list of hosts.
-  $cache_servers = lookup('profile::memcache::servers', {
-    'value_type'    => Array[String],
-    'merge'         => 'unique',
-  })
-  $memcache = $cache_servers.map | $server | {
-    "${server}:11211"
-  }
-
-  # Variables to determine if haproxy or keepalived should be configured.
-  $confhaproxy = lookup('ntnuopenstack::haproxy::configure::backend', {
-    'value_type'    => Boolean,
-    'default_value' => true,
-  })
-
-  contain ::ntnuopenstack::glance::ceph
-  contain ::ntnuopenstack::glance::firewall::server::registry
-  include ::ntnuopenstack::glance::sudo
-  include ::ntnuopenstack::glance::rabbit
-  require ::ntnuopenstack::repo
-
-  if($confhaproxy) {
-    contain ::ntnuopenstack::glance::haproxy::backend
-  }
-
-  class { '::glance::backend::rbd' :
-    rbd_store_user => 'glance',
-  }
-
   class { '::glance::registry':
-    # Auth_strategy is blank to prevent glance::registry from including
-    # ::glance::registry::authtoken.
-    auth_strategy       => '',
-    database_connection => $database_connection,
-  }
-
-  class { '::glance::registry::authtoken':
-    password             => $keystone_password,
-    auth_url             => "${keystone_internal}:5000",
-    www_authenticate_uri => "${keystone_public}:5000",
-    memcached_servers    => $memcache,
-    region_name          => $region,
+    package_ensure => 'absent',
+    enabled        => false,
   }
 }

--- a/manifests/glance/registry.pp
+++ b/manifests/glance/registry.pp
@@ -4,5 +4,6 @@ class ntnuopenstack::glance::registry {
   class { '::glance::registry':
     package_ensure => 'absent',
     enabled        => false,
+    auth_strategy  => '',
   }
 }

--- a/manifests/heat/base.pp
+++ b/manifests/heat/base.pp
@@ -4,6 +4,7 @@ class ntnuopenstack::heat::base {
   $region = lookup('ntnuopenstack::region', String)
   $keystone_admin  = lookup('ntnuopenstack::keystone::endpoint::admin', Stdlib::Httpurl)
   $keystone_internal = lookup('ntnuopenstack::keystone::endpoint::internal', Stdlib::Httpurl)
+  $db_sync = lookup('ntnuopenstack::heat::db::sync', Boolean)
 
   # Memcached servers
   $cache_servers = lookup('profile::memcache::servers', {
@@ -42,6 +43,7 @@ class ntnuopenstack::heat::base {
     default_transport_url        => $transport_url,
     region_name                  => $region,
     enable_proxy_headers_parsing => true,
+    sync_db                      => $db_sync,
     *                            => $ha_transport_conf,
   }
 }

--- a/manifests/heat/base.pp
+++ b/manifests/heat/base.pp
@@ -25,7 +25,7 @@ class ntnuopenstack::heat::base {
   # Database-connection
   $mysql_pass = lookup('ntnuopenstack::heat::mysql::password', String)
   $mysql_ip = lookup('ntnuopenstack::heat::mysql::ip', Stdlib::IP::Address)
-  $database_connection = "mysql://heat:${mysql_pass}@${mysql_ip}/heat"
+  $database_connection = "mysql+pymysql://heat:${mysql_pass}@${mysql_ip}/heat"
 
   require ::ntnuopenstack::repo
 

--- a/manifests/horizon.pp
+++ b/manifests/horizon.pp
@@ -69,7 +69,7 @@ class ntnuopenstack::horizon {
     keystone_multidomain_support   => true,
     keystone_url                   => "${keystone}:5000",
     keystone_domain_choices        => [
-      {'name'                      => $ldap_name, 'display' => $description},
+      {'name' => $ldap_name, 'display' => $description},
       {'name' => 'default',  'display' => 'Openstack accounts'},
     ],
     neutron_options                => {

--- a/manifests/horizon.pp
+++ b/manifests/horizon.pp
@@ -19,6 +19,10 @@ class ntnuopenstack::horizon {
     'default_value' => 7200,
   })
   $keystone = lookup('ntnuopenstack::keystone::endpoint::internal', Stdlib::Httpurl)
+  $help_url = lookup('ntnuopenstack::horizon::help_url', {
+    'value_type'    => Stdlib::Httpurl,
+    'default_value' => 'https://docs.openstack.org',
+  })
 
   # Try to retrieve memcache addresses.
   $memcache_servers = lookup('profile::memcache::servers', {
@@ -60,11 +64,12 @@ class ntnuopenstack::horizon {
     allowed_hosts                  => [$::fqdn, $server_name],
     default_theme                  => 'default',
     enable_secure_proxy_ssl_header => $haproxy,
+    help_url                       => $help_url,
     keystone_default_domain        => $ldap_name,
     keystone_multidomain_support   => true,
     keystone_url                   => "${keystone}:5000",
     keystone_domain_choices        => [
-      {'name' => $ldap_name, 'display' => $description},
+      {'name'                      => $ldap_name, 'display' => $description},
       {'name' => 'default',  'display' => 'Openstack accounts'},
     ],
     neutron_options                => {

--- a/manifests/keystone/base.pp
+++ b/manifests/keystone/base.pp
@@ -13,6 +13,8 @@ class ntnuopenstack::keystone::base {
   $mysql_ip = lookup('ntnuopenstack::keystone::mysql::ip', Stdlib::IP::Address)
   $db_con = "mysql://keystone:${mysql_password}@${mysql_ip}/keystone"
 
+  $sync_db = lookup('ntnuopenstack::keyston::db::sync', Boolean)
+
   $cache_servers = lookup('profile::memcache::servers', {
     'value_type'    => Variant[Array[String], Boolean],
     'default_value' => false,
@@ -77,6 +79,7 @@ class ntnuopenstack::keystone::base {
     enable_proxy_headers_parsing => $confhaproxy,
     using_domain_config          => true,
     token_expiration             => $token_expiration,
+    sync_db                      => $sync_db,
     *                            => $keystone_opts,
   }
 

--- a/manifests/keystone/base.pp
+++ b/manifests/keystone/base.pp
@@ -13,7 +13,7 @@ class ntnuopenstack::keystone::base {
   $mysql_ip = lookup('ntnuopenstack::keystone::mysql::ip', Stdlib::IP::Address)
   $db_con = "mysql://keystone:${mysql_password}@${mysql_ip}/keystone"
 
-  $sync_db = lookup('ntnuopenstack::keyston::db::sync', Boolean)
+  $sync_db = lookup('ntnuopenstack::keystone::db::sync', Boolean)
 
   $cache_servers = lookup('profile::memcache::servers', {
     'value_type'    => Variant[Array[String], Boolean],

--- a/manifests/neutron/agents.pp
+++ b/manifests/neutron/agents.pp
@@ -28,6 +28,6 @@ class ntnuopenstack::neutron::agents {
   class { '::neutron::agents::l3':
     ha_enabled            => true,
     ha_vrrp_auth_password => $neutron_vrrp_pass,
-    extensions            => 'fwaas,port_forwarding',
+    extensions            => 'fwaas_v2,port_forwarding',
   }
 }

--- a/manifests/neutron/agents.pp
+++ b/manifests/neutron/agents.pp
@@ -28,6 +28,6 @@ class ntnuopenstack::neutron::agents {
   class { '::neutron::agents::l3':
     ha_enabled            => true,
     ha_vrrp_auth_password => $neutron_vrrp_pass,
-    extensions            => 'fwaas',
+    extensions            => 'fwaas,port_forwarding',
   }
 }

--- a/manifests/neutron/api.pp
+++ b/manifests/neutron/api.pp
@@ -80,4 +80,7 @@ class ntnuopenstack::neutron::api {
 
   class { 'neutron::services::lbaas':
   }
+
+  class { 'neutron::services::fwaas':
+  }
 }

--- a/manifests/neutron/api.pp
+++ b/manifests/neutron/api.pp
@@ -3,7 +3,8 @@ class ntnuopenstack::neutron::api {
   # Determine where the database is
   $mysql_password = lookup('ntnuopenstack::neutron::mysql::password', String)
   $mysql_ip = lookup('ntnuopenstack::neutron::mysql::ip', Stdlib::IP::Address)
-  $database_connection = "mysql://neutron:${mysql_password}@${mysql_ip}/neutron"
+  $database_connection = "mysql+pymysql://neutron:${mysql_password}@${mysql_ip}/neutron"
+  $sync_db = lookup('ntnuopenstack::neutron::db::sync', Boolean)
 
   # Create a list of memceche-servers.
   $cache_servers = lookup('profile::memcache::servers', {
@@ -53,17 +54,17 @@ class ntnuopenstack::neutron::api {
 
   # Configure how neutron communicates with keystone
   class { '::neutron::keystone::authtoken':
-    password          => $neutron_password,
-    auth_url          => "${keystone_admin}:35357/",
-    auth_uri          => "${keystone_internal}:5000/",
-    memcached_servers => $memcache,
-    region_name       => $region,
+    password             => $neutron_password,
+    auth_url             => "${keystone_admin}:35357/",
+    www_authenticate_uri => "${keystone_internal}:5000/",
+    memcached_servers    => $memcache,
+    region_name          => $region,
   }
 
   # Install the neutron api
   class { '::neutron::server':
     database_connection              => $database_connection,
-    sync_db                          => true,
+    sync_db                          => $sync_db,
     allow_automatic_l3agent_failover => true,
     allow_automatic_dhcp_failover    => true,
     service_providers                => $service_providers,

--- a/manifests/neutron/api.pp
+++ b/manifests/neutron/api.pp
@@ -26,7 +26,7 @@ class ntnuopenstack::neutron::api {
   $service_providers = lookup('ntnuopenstack::neutron::service_providers', {
     'value_type'    => Array[String],
     'default_value' => [
-      'FIREWALL:Iptables:neutron.agent.linux.iptables_firewall.OVSHybridIptablesFirewallDriver:default',
+      'FIREWALL_V2:fwaas_db:neutron_fwaas.services.firewall.service_drivers.agents.agents.FirewallAgentDriver:default',
       'LOADBALANCERV2:Haproxy:neutron_lbaas.drivers.haproxy.plugin_driver.HaproxyOnHostPluginDriver:default',
     ],
   })

--- a/manifests/neutron/base.pp
+++ b/manifests/neutron/base.pp
@@ -6,6 +6,7 @@ class ntnuopenstack::neutron::base {
       'router',
       'firewall',
       'neutron_lbaas.services.loadbalancer.plugin.LoadBalancerPluginv2',
+      'port_forwarding',
     ],
   })
   $mtu = lookup('ntnuopenstack::neutron::mtu', {

--- a/manifests/neutron/base.pp
+++ b/manifests/neutron/base.pp
@@ -4,7 +4,7 @@ class ntnuopenstack::neutron::base {
     'value_type'    => Array[String],
     'default_value' => [
       'router',
-      'firewall',
+      'firewall_v2',
       'neutron_lbaas.services.loadbalancer.plugin.LoadBalancerPluginv2',
       'port_forwarding',
     ],

--- a/manifests/neutron/ovs.pp
+++ b/manifests/neutron/ovs.pp
@@ -24,4 +24,8 @@ class ntnuopenstack::neutron::ovs (
     local_ip        => $local_ip,
     tunnel_types    => $tunnel_types,
   }
+
+  neutron_agent_ovs { 'ovs/ovsdb_timeout':
+    value => 60,
+  }
 }

--- a/manifests/neutron/services.pp
+++ b/manifests/neutron/services.pp
@@ -3,7 +3,7 @@ class ntnuopenstack::neutron::services {
   $fw_driver = lookup('ntnuopenstack::neutron::fwaas_driver', {
     'value_type'    => String,
     'default_value' =>
-      'neutron_fwaas.services.firewall.drivers.linux.iptables_fwaas_v2.IptablesFwaasDriver',
+      'neutron_fwaas.services.firewall.service_drivers.agents.drivers.linux.iptables_fwaas_v2.IptablesFwaasDriver',
   })
 
   require ::ntnuopenstack::neutron::base

--- a/manifests/neutron/services.pp
+++ b/manifests/neutron/services.pp
@@ -3,7 +3,7 @@ class ntnuopenstack::neutron::services {
   $fw_driver = lookup('ntnuopenstack::neutron::fwaas_driver', {
     'value_type'    => String,
     'default_value' =>
-      'neutron_fwaas.services.firewall.drivers.linux.iptables_fwaas.IptablesFwaasDriver',
+      'neutron_fwaas.services.firewall.drivers.linux.iptables_fwaas_v2.IptablesFwaasDriver',
   })
 
   require ::ntnuopenstack::neutron::base
@@ -12,7 +12,7 @@ class ntnuopenstack::neutron::services {
   class { '::neutron::services::fwaas':
     enabled       => true,
     driver        => $fw_driver,
-    agent_version => 'v1',
+    agent_version => 'v2',
   }
 
   class { '::neutron::services::lbaas':

--- a/manifests/nova/api.pp
+++ b/manifests/nova/api.pp
@@ -2,4 +2,5 @@
 class ntnuopenstack::nova::api {
   contain ::ntnuopenstack::nova::api::compute
   contain ::ntnuopenstack::nova::api::placement
+  contain ::ntnuopenstack::nova::api::metadata
 }

--- a/manifests/nova/api/compute.pp
+++ b/manifests/nova/api/compute.pp
@@ -12,7 +12,6 @@ class ntnuopenstack::nova::api::compute {
 
   # Retrieve openstack parameters
   $nova_password = lookup('ntnuopenstack::nova::keystone::password')
-  $nova_secret = lookup('ntnuopenstack::nova::sharedmetadataproxysecret')
   $sync_db = lookup('ntnuopenstack::nova::db::sync', {
     'value_type'    => Boolean,
     'default_value' => false,   # One of your nodes need to have this key set to
@@ -30,7 +29,6 @@ class ntnuopenstack::nova::api::compute {
   include ::ntnuopenstack::nova::neutron
 
   contain ::ntnuopenstack::nova::haproxy::backend::api
-  contain ::ntnuopenstack::nova::haproxy::backend::metadata
 
   class { '::nova::keystone::authtoken':
     auth_url             => "${admin_endpoint}:35357/",
@@ -41,10 +39,17 @@ class ntnuopenstack::nova::api::compute {
   }
 
   class { '::nova::api':
-    neutron_metadata_proxy_shared_secret => $nova_secret,
-    enable_proxy_headers_parsing         => true,
-    sync_db                              => $sync_db,
-    sync_db_api                          => $sync_db,
-    use_forwarded_for                    => true,
+    enabled                      => false,
+    enable_proxy_headers_parsing => true,
+    nova_metadata_wsgi_enabled   => true,
+    service_name                 => 'httpd',
+    sync_db                      => $sync_db,
+    sync_db_api                  => $sync_db,
+    use_forwarded_for            => true,
+  }
+
+  class { '::nova::wsgi::apache_api':
+    ssl               => false,
+    access_log_format => 'forwarded',
   }
 }

--- a/manifests/nova/api/compute.pp
+++ b/manifests/nova/api/compute.pp
@@ -13,7 +13,7 @@ class ntnuopenstack::nova::api::compute {
   # Retrieve openstack parameters
   $nova_password = lookup('ntnuopenstack::nova::keystone::password')
   $nova_secret = lookup('ntnuopenstack::nova::sharedmetadataproxysecret')
-  $sync_db = lookup('ntnuopenstack::nova::sync_db', {
+  $sync_db = lookup('ntnuopenstack::nova::db::sync', {
     'value_type'    => Boolean,
     'default_value' => false,   # One of your nodes need to have this key set to
                                 # true to automaticly populate the databases.
@@ -33,11 +33,11 @@ class ntnuopenstack::nova::api::compute {
   contain ::ntnuopenstack::nova::haproxy::backend::metadata
 
   class { '::nova::keystone::authtoken':
-    auth_url          => "${admin_endpoint}:35357/",
-    auth_uri          => "${internal_endpoint}:5000/",
-    password          => $nova_password,
-    memcached_servers => $memcache,
-    region_name       => $region,
+    auth_url             => "${admin_endpoint}:35357/",
+    www_authenticate_uri => "${internal_endpoint}:5000/",
+    password             => $nova_password,
+    memcached_servers    => $memcache,
+    region_name          => $region,
   }
 
   class { '::nova::api':

--- a/manifests/nova/api/metadata.pp
+++ b/manifests/nova/api/metadata.pp
@@ -7,7 +7,7 @@ class ntnuopenstack::nova::api::metadata {
   $neutron_secret = lookup('ntnuopenstack::nova::sharedmetadataproxysecret')
 
   if($confhaproxy) {
-    contain ::ntnuopenstack::haproxy::backend::metadata
+    contain ::ntnuopenstack::nova::haproxy::backend::metadata
     $header_parsing = true
     $logformat = 'forwarded'
   } else {

--- a/manifests/nova/api/metadata.pp
+++ b/manifests/nova/api/metadata.pp
@@ -1,0 +1,29 @@
+# Installs nova-metadata as WSGI in apache
+class ntnuopenstack::nova::api::metadata {
+  $confhaproxy = lookup('ntnuopenstack::haproxy::configure::backend', {
+    'value_type'    => Boolean,
+    'default_value' => true,
+  })
+  $neutron_secret = lookup('ntnuopenstack::nova::sharedmetadataproxysecret')
+
+  if($confhaproxy) {
+    contain ::ntnuopenstack::haproxy::backend::metadata
+    $header_parsing = true
+    $logformat = 'forwarded'
+  } else {
+    $header_parsing = false
+    $logformat = false
+  }
+
+  class { '::nova::metadata':
+    enable_proxy_headers_parsing         => $header_parsing,
+    neutron_metadata_proxy_shared_secret => $neutron_secret,
+  }
+
+  class { '::nova::wsgi::apache_metadata':
+    access_log_format => $logformat,
+    ssl               => false,
+  }
+}
+
+

--- a/manifests/nova/base.pp
+++ b/manifests/nova/base.pp
@@ -14,8 +14,8 @@ class ntnuopenstack::nova::base {
   $mysql_ip = lookup('ntnuopenstack::nova::mysql::ip', {
       'value_type' => Stdlib::IP::Address,
   })
-  $db_con = "mysql://nova:${mysql_password}@${mysql_ip}/nova"
-  $api_db_con = "mysql://nova_api:${mysql_password}@${mysql_ip}/nova_api"
+  $db_con = "mysql+pymysql://nova:${mysql_password}@${mysql_ip}/nova"
+  $api_db_con = "mysql+pymysql://nova_api:${mysql_password}@${mysql_ip}/nova_api"
 
   # Nova placement configuration
   $region = lookup('ntnuopenstack::region')

--- a/manifests/nova/compute.pp
+++ b/manifests/nova/compute.pp
@@ -56,7 +56,7 @@ class ntnuopenstack::nova::compute {
   if ($install_sensu) {
     sensu::subscription { 'os-compute': }
   }
-  ensure_package( ['python3-pymysql'] , {
+  ensure_packages( ['python3-pymysql'] , {
     'ensure' => 'present',
   })
 }

--- a/manifests/nova/compute.pp
+++ b/manifests/nova/compute.pp
@@ -56,5 +56,8 @@ class ntnuopenstack::nova::compute {
   if ($install_sensu) {
     sensu::subscription { 'os-compute': }
   }
+  ensure_package( ['python3-pymysql'] , {
+    'ensure' => 'present',
+  })
 }
 

--- a/manifests/nova/compute.pp
+++ b/manifests/nova/compute.pp
@@ -48,5 +48,13 @@ class ntnuopenstack::nova::compute {
     libvirt_rbd_secret_uuid => $nova_uuid,
     manage_ceph_client      => false,
   }
+
+  $install_sensu = lookup('profile::sensu::install', {
+    'default_value' => true,
+    'value_type'    => Boolean,
+  })
+  if ($install_sensu) {
+    sensu::subscription { 'os-compute': }
+  }
 }
 

--- a/manifests/nova/firewall/server.pp
+++ b/manifests/nova/firewall/server.pp
@@ -12,9 +12,4 @@ class ntnuopenstack::nova::firewall::server {
     protocol => 'tcp',
     port     => 8778,
   }
-
-  firewall { '511 nova-api-INPUT':
-    jump  => 'nova-api-INPUT',
-    proto => 'all',
-  }
 }

--- a/manifests/nova/services.pp
+++ b/manifests/nova/services.pp
@@ -27,7 +27,6 @@ class ntnuopenstack::nova::services {
   })
 
   class { [
-    '::nova::consoleauth',
     '::nova::conductor'
   ]:
     enabled => true,

--- a/manifests/nova/services.pp
+++ b/manifests/nova/services.pp
@@ -26,10 +26,12 @@ class ntnuopenstack::nova::services {
     'value_type'    => Integer,
   })
 
-  class { [
-    '::nova::conductor'
-  ]:
+  class { '::nova::conductor':
     enabled => true,
+  }
+
+  class { '::nova::consoleauth':
+    ensure_package => 'purged',
   }
 
   class { '::nova::scheduler':

--- a/manifests/nova/services.pp
+++ b/manifests/nova/services.pp
@@ -31,6 +31,8 @@ class ntnuopenstack::nova::services {
   }
 
   class { '::nova::consoleauth':
+    enabled        => false,
+    manage_service => false,
     ensure_package => 'purged',
   }
 

--- a/manifests/nova/services.pp
+++ b/manifests/nova/services.pp
@@ -43,4 +43,9 @@ class ntnuopenstack::nova::services {
   class { '::nova::scheduler::filter':
     scheduler_default_filters => $default_filters_real,
   }
+
+  nova_config {
+    'filter_scheduler/build_failure_weight_multiplier':
+      value => 0;
+  }
 }

--- a/manifests/swift/radosgw.pp
+++ b/manifests/swift/radosgw.pp
@@ -2,10 +2,12 @@
 class ntnuopenstack::swift::radosgw {
   $endpoint_internal = lookup('ntnuopenstack::endpoint::internal')
   $keystone_password = lookup('ntnuopenstack::swift::keystone::password')
+  $swift_dns_name = lookup('ntnuopenstack::swift::dns::name')
 
   ::ceph::rgw { 'radosgw.main':
-    pkg_radosgw => 'radosgw',
-    user        => 'www-data',
+    pkg_radosgw  => 'radosgw',
+    rgw_dns_name => $swift_dns_name,
+    user         => 'www-data',
   }
 
   ::ceph::rgw::keystone { 'radosgw.main':


### PR DESCRIPTION
The following changes are introduced when ntnuopenstack was prepared for rocky:
 - Automatic db-sync is turned off. Useful for on-line upgrades where such operations should be controlled by an administrator.
 - Removed the glance-registry
 - Add support for custom help-url in horizon.
 - Adds support for the neutrons dragent with the BGP plugin
 - Enable neutron port forwarding
 - Replaces fwaas v1 with fwaas v2.
 - Adds nova-api and nova-metadata as a apache-wsgi-service
 - Disables the nova-consoleauth service
 - Correctly configures hostname for the radosgw's
 - Ensure that all DB connection strings has the driver name specified (usually mysql+pymysql://...)

New hiera-keys:
 - `ntnuopenstack::horizon::help_url` - The url which the horizon's help-button should point to.
 - `ntnuopenstack::neutron::bgp::router::id` - The BGP Router-ID a nework-node should use if it peers with BGP.
 - `ntnuopenstack::swift::dns::name` - The domain-name used to access S3/Swift