### PR TITLE
Stein

### DIFF
--- a/manifests/cinder/ceph.pp
+++ b/manifests/cinder/ceph.pp
@@ -11,7 +11,7 @@ class ntnuopenstack::cinder::ceph {
 
   ceph::key { 'client.cinder':
     secret  => $ceph_key,
-    cap_mon => 'allow r, allow command \"osd blacklist\"',
+    cap_mon => 'allow r, allow command "osd blacklist"',
     cap_osd =>
       'allow class-read object_prefix rbd_children, allow rwx pool=volumes',
     inject  => true,

--- a/manifests/cinder/scheduler.pp
+++ b/manifests/cinder/scheduler.pp
@@ -3,8 +3,5 @@ class ntnuopenstack::cinder::scheduler {
   require ::ntnuopenstack::repo
   require ::ntnuopenstack::cinder::base
 
-  class { '::cinder::scheduler':
-    enabled          => true,
-  }
-
+  class { '::cinder::scheduler': }
 }

--- a/manifests/glance.pp
+++ b/manifests/glance.pp
@@ -2,5 +2,4 @@
 # the SkyHiGh architecture
 class ntnuopenstack::glance {
   contain ::ntnuopenstack::glance::api
-  contain ::ntnuopenstack::glance::registry
 }

--- a/manifests/glance/ceph.pp
+++ b/manifests/glance/ceph.pp
@@ -14,7 +14,7 @@ class ntnuopenstack::glance::ceph {
 
   ceph::key { 'client.glance':
     secret  => $glance_key,
-    cap_mon => 'allow r, allow command \"osd blacklist\"',
+    cap_mon => 'allow r, allow command "osd blacklist"',
     cap_osd =>
       'allow class-read object_prefix rbd_children, allow rwx pool=images',
     inject  => true,

--- a/manifests/glance/ceph.pp
+++ b/manifests/glance/ceph.pp
@@ -21,6 +21,7 @@ class ntnuopenstack::glance::ceph {
   }
 
   class { '::glance::backend::rbd' :
-    rbd_store_user => 'glance',
+    rbd_store_user  => 'glance',
+    manage_packages => false,
   }
 }

--- a/manifests/glance/registry.pp
+++ b/manifests/glance/registry.pp
@@ -1,9 +1,0 @@
-# Ensures that glance-registry is disabled and removed. It is deprecated as of
-# Queens, and will be removed at Stein.  
-class ntnuopenstack::glance::registry {
-  class { '::glance::registry':
-    package_ensure => 'absent',
-    enabled        => false,
-    auth_strategy  => '',
-  }
-}

--- a/manifests/horizon.pp
+++ b/manifests/horizon.pp
@@ -58,7 +58,10 @@ class ntnuopenstack::horizon {
 
   horizon::dashboard { 'heat': }
   horizon::dashboard { 'neutron-fwaas': }
-  horizon::dashboard { 'neutron-lbaas': }
+
+  horizon::dashboard { 'neutron-lbaas':
+    ensure => 'absent',
+  }
 
   class { '::horizon':
     allowed_hosts                  => [$::fqdn, $server_name],

--- a/manifests/keystone/base.pp
+++ b/manifests/keystone/base.pp
@@ -94,4 +94,7 @@ class ntnuopenstack::keystone::base {
     ssl               => false,
     access_log_format => $logformat,
   }
+  ensure_packages( ['python3-mysqldb', 'python3-ldappool'] , {
+    'ensure' => 'present',
+  })
 }

--- a/manifests/keystone/base.pp
+++ b/manifests/keystone/base.pp
@@ -47,10 +47,10 @@ class ntnuopenstack::keystone::base {
     }
 
     $keystone_opts = {
-      'memcache_servers' => $memcache,
-      'cache_backend'    => 'dogpile.cache.memcached',
-      'cache_enabled'    => true,
-      'token_caching'    => true,
+      'cache_memcache_servers' => $memcache,
+      'cache_backend'          => 'dogpile.cache.memcached',
+      'cache_enabled'          => true,
+      'token_caching'          => true,
     }
   } else {
     $keystone_opts = {}
@@ -69,7 +69,7 @@ class ntnuopenstack::keystone::base {
     enabled                      => false,
     service_name                 => 'httpd',
     admin_bind_host              => '0.0.0.0',
-    admin_endpoint               => "${admin_endpoint}:35357/",
+    admin_endpoint               => "${admin_endpoint}:5000/",
     public_endpoint              => "${public_endpoint}:5000/",
     token_provider               => 'fernet',
     fernet_keys                  => $fernet_keys,

--- a/manifests/keystone/endpoint.pp
+++ b/manifests/keystone/endpoint.pp
@@ -30,7 +30,7 @@ class ntnuopenstack::keystone::endpoint {
   # Defining the keystone endpoint
   class { '::keystone::endpoint':
     public_url   => "${public_endpoint}:5000",
-    admin_url    => "${admin_endpoint}:35357",
+    admin_url    => "${admin_endpoint}:5000",
     internal_url => "${internal_endpoint}:5000",
     region       => $region,
     require      => Class['::keystone'],

--- a/manifests/keystone/firewall/server.pp
+++ b/manifests/keystone/firewall/server.pp
@@ -4,6 +4,6 @@
 class ntnuopenstack::keystone::firewall::server {
   ::profile::baseconfig::firewall::service::infra { 'Keystone-API':
     protocol => 'tcp',
-    port     => [5000,35357],
+    port     => 5000,
   }
 }

--- a/manifests/keystone/haproxy/backend.pp
+++ b/manifests/keystone/haproxy/backend.pp
@@ -16,19 +16,6 @@ class ntnuopenstack::keystone::haproxy::backend {
     options           => 'check inter 2000 rise 2 fall 5',
   }
 
-  profile::services::haproxy::tools::register { "KeystoneAdmin-${::hostname}":
-    servername  => $::hostname,
-    backendname => 'bk_keystone_admin',
-  }
-
-  @@haproxy::balancermember { "keystone-admin-${::fqdn}":
-    listening_service => 'bk_keystone_admin',
-    server_names      => $::hostname,
-    ipaddresses       => $ip,
-    ports             => '35357',
-    options           => 'check inter 2000 rise 2 fall 5',
-  }
-
   profile::services::haproxy::tools::register { "KeystoneInternal-${::hostname}":
     servername  => $::hostname,
     backendname => 'bk_keystone_internal',
@@ -36,6 +23,25 @@ class ntnuopenstack::keystone::haproxy::backend {
 
   @@haproxy::balancermember { "keystone-internal-${::fqdn}":
     listening_service => 'bk_keystone_internal',
+    server_names      => $::hostname,
+    ipaddresses       => $ip,
+    ports             => '5000',
+    options           => 'check inter 2000 rise 2 fall 5',
+  }
+ 
+  # To be removed in the TRAIN relase:
+  #
+  # The keystone admin interface (port 35357) is deprecated, and removed in
+  # Stein. We have services using 35357 in the rocky relase, so to allow smooth
+  # upgrades we let the keystone-admin haproxy service live until Train. It is
+  # however connected to the regular keystone port behind the load-balancer.
+  profile::services::haproxy::tools::register { "KeystoneAdmin-${::hostname}":
+    servername  => $::hostname,
+    backendname => 'bk_keystone_admin',
+  }
+
+  @@haproxy::balancermember { "keystone-admin-${::fqdn}":
+    listening_service => 'bk_keystone_admin',
     server_names      => $::hostname,
     ipaddresses       => $ip,
     ports             => '5000',

--- a/manifests/neutron/api.pp
+++ b/manifests/neutron/api.pp
@@ -30,10 +30,6 @@ class ntnuopenstack::neutron::api {
       'LOADBALANCERV2:Haproxy:neutron_lbaas.drivers.haproxy.plugin_driver.HaproxyOnHostPluginDriver:default',
     ],
   })
-  $enable_ipv6_pd = lookup('ntnuopenstack::neutron::tenant::dhcpv6pd', {
-    'value_type'    => Boolean,
-    'default_value' => false,
-  })
   $confhaproxy = lookup('ntnuopenstack::haproxy::configure::backend', {
     'value_type'    => Boolean,
     'default_value' => true,
@@ -44,9 +40,9 @@ class ntnuopenstack::neutron::api {
   include ::ntnuopenstack::neutron::ml2::config
   include ::profile::services::memcache::pythonclient
 
-  if ($enable_ipv6_pd) {
-    contain ::ntnuopenstack::neutron::ipv6::config
-  }
+  # his class is to remove the rest of the DHCPv6-pd config. This can be removed
+  # when upgrading to Train.
+  contain ::ntnuopenstack::neutron::ipv6::pddisable
 
   if($confhaproxy) {
     contain ::ntnuopenstack::neutron::haproxy::backend

--- a/manifests/neutron/api.pp
+++ b/manifests/neutron/api.pp
@@ -55,7 +55,7 @@ class ntnuopenstack::neutron::api {
   # Configure how neutron communicates with keystone
   class { '::neutron::keystone::authtoken':
     password             => $neutron_password,
-    auth_url             => "${keystone_admin}:35357/",
+    auth_url             => "${keystone_admin}:5000/",
     www_authenticate_uri => "${keystone_internal}:5000/",
     memcached_servers    => $memcache,
     region_name          => $region,
@@ -74,7 +74,7 @@ class ntnuopenstack::neutron::api {
   # Configure nova notifications system
   class { '::neutron::server::notifications':
     password    => $nova_password,
-    auth_url    => "${keystone_admin}:35357",
+    auth_url    => "${keystone_admin}:5000",
     region_name => $region,
   }
 

--- a/manifests/neutron/ipv6/agent.pp
+++ b/manifests/neutron/ipv6/agent.pp
@@ -1,9 +1,0 @@
-# This class installs dibbler-client, and the required config.
-# Intended for neutron network nodes
-class ntnuopenstack::neutron::ipv6::agent {
-  include ::ntnuopenstack::neutron::ipv6::config
-
-  package { 'dibbler-client':
-    ensure => 'present',
-  }
-}

--- a/manifests/neutron/ipv6/config.pp
+++ b/manifests/neutron/ipv6/config.pp
@@ -1,6 +1,0 @@
-# Configures neutron to allow IPv6 delegation to tenant subnets trough dhcpv6-pd
-class ntnuopenstack::neutron::ipv6::config {
-  neutron_config {
-    'DEFAULT/ipv6_pd_enabled': value => 'True';
-  }
-}

--- a/manifests/neutron/ipv6/pddisable.pp
+++ b/manifests/neutron/ipv6/pddisable.pp
@@ -1,0 +1,10 @@
+# This class disables the IPv6 pd implementation. We should use BGP instead.
+# This class should be removed when upgrading to Train.
+class ntnuopenstack::neutron::ipv6::pddisable {
+  package { 'dibbler-client':
+    ensure => 'absent',
+  }
+  neutron_config {
+    'DEFAULT/ipv6_pd_enabled': ensure => 'absent';
+  }
+}

--- a/manifests/neutron/network.pp
+++ b/manifests/neutron/network.pp
@@ -1,10 +1,5 @@
 # Installs and configures a neutron network node
 class ntnuopenstack::neutron::network {
-  $enable_ipv6_pd = lookup('ntnuopenstack::neutron::tenant::dhcpv6pd', {
-    'value_type'    => Boolean,
-    'default_value' => false,
-  })
-
   require ::ntnuopenstack::repo
 
   contain ::ntnuopenstack::neutron::agents
@@ -14,5 +9,7 @@ class ntnuopenstack::neutron::network {
   contain ::ntnuopenstack::neutron::services
   contain ::ntnuopenstack::neutron::tenant
 
+  # This class is to remove the rest of the DHCPv6-pd config. This can be
+  # removed when upgrading to Train.
   contain ::ntnuopenstack::neutron::ipv6::pddisable
 }

--- a/manifests/neutron/network.pp
+++ b/manifests/neutron/network.pp
@@ -14,7 +14,5 @@ class ntnuopenstack::neutron::network {
   contain ::ntnuopenstack::neutron::services
   contain ::ntnuopenstack::neutron::tenant
 
-  if ($enable_ipv6_pd) {
-    contain ::ntnuopenstack::neutron::ipv6::agent
-  }
+  contain ::ntnuopenstack::neutron::ipv6::pddisable
 }

--- a/manifests/nova/api/compute.pp
+++ b/manifests/nova/api/compute.pp
@@ -31,7 +31,7 @@ class ntnuopenstack::nova::api::compute {
   contain ::ntnuopenstack::nova::haproxy::backend::api
 
   class { '::nova::keystone::authtoken':
-    auth_url             => "${admin_endpoint}:35357/",
+    auth_url             => "${admin_endpoint}:5000/",
     www_authenticate_uri => "${internal_endpoint}:5000/",
     password             => $nova_password,
     memcached_servers    => $memcache,

--- a/manifests/nova/base.pp
+++ b/manifests/nova/base.pp
@@ -53,9 +53,9 @@ class ntnuopenstack::nova::base {
   }
 
   class { '::nova::placement':
-    password       => $placement_password,
-    auth_url       => "${keystone_admin}:35357/v3",
-    os_region_name => $region,
+    password    => $placement_password,
+    auth_url    => "${keystone_admin}:5000/v3",
+    region_name => $region,
   }
 
   class { '::nova::cache' :

--- a/manifests/nova/base/compute.pp
+++ b/manifests/nova/base/compute.pp
@@ -40,6 +40,6 @@ class ntnuopenstack::nova::base::compute {
   class { '::nova::placement':
     password       => $placement_password,
     auth_url       => "${internal_endpoint}:5000/v3",
-    os_region_name => $region,
+    region_name => $region,
   }
 }

--- a/manifests/nova/base/compute.pp
+++ b/manifests/nova/base/compute.pp
@@ -39,7 +39,7 @@ class ntnuopenstack::nova::base::compute {
 
   class { '::nova::placement':
     password       => $placement_password,
-    auth_url       => "${internal_endpoint}:35357/v3",
+    auth_url       => "${internal_endpoint}:5000/v3",
     os_region_name => $region,
   }
 }

--- a/manifests/nova/ceph.pp
+++ b/manifests/nova/ceph.pp
@@ -12,10 +12,6 @@ class ntnuopenstack::nova::ceph {
     'client.nova/key': value => $nova_key;
   }
 
-  ensure_packages( ['python3-rbd', 'python3-rados'] , {
-    'ensure' => 'present',
-  })
-
   $top = 'allow class-read object_prefix rbd_children'
   $volumes = 'allow rwx pool=volumes'
   $images = 'allow rwx pool=images'

--- a/manifests/nova/ceph.pp
+++ b/manifests/nova/ceph.pp
@@ -17,7 +17,7 @@ class ntnuopenstack::nova::ceph {
   $images = 'allow rwx pool=images'
   ceph::key { 'client.nova':
     secret  => $nova_key,
-    cap_mon => 'allow r, allow command \"osd blacklist\"',
+    cap_mon => 'allow r, allow command "osd blacklist"',
     cap_osd => "${top},${volumes}, ${images}",
     inject  => true,
   }

--- a/manifests/nova/ceph.pp
+++ b/manifests/nova/ceph.pp
@@ -12,6 +12,10 @@ class ntnuopenstack::nova::ceph {
     'client.nova/key': value => $nova_key;
   }
 
+  ensure_packages( ['python3-rbd', 'python3-rados'] , {
+    'ensure' => 'present',
+  })
+
   $top = 'allow class-read object_prefix rbd_children'
   $volumes = 'allow rwx pool=volumes'
   $images = 'allow rwx pool=images'

--- a/manifests/nova/compute.pp
+++ b/manifests/nova/compute.pp
@@ -56,7 +56,7 @@ class ntnuopenstack::nova::compute {
   if ($install_sensu) {
     sensu::subscription { 'os-compute': }
   }
-  ensure_packages( ['python3-pymysql'] , {
+  ensure_packages( ['python3-rbd', 'python3-pymysql'] , {
     'ensure' => 'present',
   })
 }

--- a/manifests/nova/compute.pp
+++ b/manifests/nova/compute.pp
@@ -56,7 +56,7 @@ class ntnuopenstack::nova::compute {
   if ($install_sensu) {
     sensu::subscription { 'os-compute': }
   }
-  ensure_packages( ['python3-rbd', 'python3-pymysql'] , {
+  ensure_packages( ['python3-pymysql'] , {
     'ensure' => 'present',
   })
 }

--- a/manifests/nova/neutron.pp
+++ b/manifests/nova/neutron.pp
@@ -19,8 +19,7 @@ class ntnuopenstack::nova::neutron {
     default_floating_pool => $floating_pool,
     neutron_region_name   => $region,
     neutron_password      => $neutron_password,
-    neutron_url           => "${neutron_internal}:9696",
-    neutron_auth_url      => "${keystone_internal}:35357/v3",
+    neutron_auth_url      => "${keystone_internal}:5000/v3",
     vif_plugging_is_fatal => false,
     vif_plugging_timeout  => '0',
   }


### PR DESCRIPTION
This PR bring in changes needed for stein:
 - The glance-registry which was disabled in rocky is now completely removed
 - neutron-lbaas is removed. It is a little-used feature, and we are soon going for octavia. (Actually, it is only hidden from horizon; it still works. shhh!)
 - The first steps to remove keystones admin-api is done. It is disabled on the keystone-nodes, and haproxy simply forwards requests to the admin API to the regular keystone API. This behaviour will be removed in Train.
 - DHCPv6-pd support is removed. We should use BGP-peering instead (Added in the rocky-release from ntnuopenstack).