### PR TITLE
Unified uplink

### DIFF
--- a/manifests/neutron/external.pp
+++ b/manifests/neutron/external.pp
@@ -19,6 +19,7 @@ class ntnuopenstack::neutron::external {
       # present at a certain VLAN on a certain vswitch bridge.
       if($data['type'] == 'vswitch') {
         $n = "Connection between ${data['bridge']} and br-${netname}"
+        ::profile::infrastructure::ovs::bridge { "br-${netname}" : }
         ::profile::infrastructure::ovs::patch::vlan { $n:
           source_bridge      => $data['bridge'],
           source_vlan        => $data['vlan'],

--- a/manifests/neutron/external.pp
+++ b/manifests/neutron/external.pp
@@ -5,31 +5,60 @@ class ntnuopenstack::neutron::external {
     'value_type' => Hash[String, Hash],
   })
   $connections = lookup('ntnuopenstack::neutron::external::connections', {
-    'value_type'    => Hash[String, String],
+    'value_type'    => Hash[String, Variant[String, Hash]],
     'default_value' => {},
   })
 
   require ::vswitch::ovs
 
   # For each connection to an external network this l3-node should create:
-  $connections.each | $netname, $interface | {
-    # If a VLAN-ID is set there is a need for a virtual patch between the ovs
-    # bridge connected to the physical interface and the ovs bridge representing
-    # the virtual network.
-    if('vlanid' in $externalnets[$netname]) {
-      $n = "${interface}-${externalnets[$netname]['vlanid']}-br-${netname}"
-      ::profile::infrastructure::ovs::patch { $n :
-        physical_if => $interface,
-        vlan_id     => $externalnets[$netname]['vlanid'],
-        ovs_bridge  => "br-${netname}",
+  $connections.each | $netname, $data | {
+    # If the data is a hash, its the new-style configuration.
+    if($data =~ Hash) {
+      # A 'vswitch' connection would indicate that an external network is
+      # present at a certain VLAN on a certain vswitch bridge.
+      if($data['type'] == 'vswitch') {
+        $n = "Connection between ${data['bridge']} and br-${netname}"
+        ::profile::infrastructure::ovs::patch::vlan { $n:
+          source_bridge      => $data['bridge'],
+          source_vlan        => $data['vlan'],
+          destination_bridge => "br-${netname}",
+        }
+
+      # An 'interface' connection would mean that a physical interface is
+      # dedicated to a certain external network.
+      } elsif ($data['type'] == 'interface') {
+        vs_port { $data['interface']:
+          ensure => present,
+          bridge => "br-${netname}",
+        }
+
+      # It an unknown type is defined; fail with an error.
+      } else {
+        fail("${data['type']} is an invalid type for an external network")
       }
 
-    # If there is not a VLAN ID set the bridge representing the virtual network
-    # can simply be connected to the physical interface
-    } else {
-      vs_port { $interface:
-        ensure => present,
-        bridge => "br-${netname}",
+    # If the data is a string, we use 'old-style' syntax, and in that case data
+    # should be an interface name.
+    } elsif($data =~ String) {
+      # If a VLAN-ID is set there is a need for a virtual patch between the ovs
+      # bridge connected to the physical interface and the ovs bridge representing
+      # the virtual network.
+      if('vlanid' in $externalnets[$netname]) {
+        $n = "${data}-${externalnets[$netname]['vlanid']}-br-${netname}"
+        ::profile::infrastructure::ovs::patch { $n :
+          physical_if => $data,
+          vlan_id     => $externalnets[$netname]['vlanid'],
+          ovs_bridge  => "br-${netname}",
+        }
+
+      # If there is not a VLAN ID set the bridge representing the virtual network
+      # can simply be connected to the physical interface
+      } else {
+        vs_port { $data:
+          ensure => present,
+          bridge => "br-${netname}",
+        }
       }
     }
   }

--- a/manifests/neutron/ovs.pp
+++ b/manifests/neutron/ovs.pp
@@ -1,8 +1,9 @@
 # This class configures the neutron ml2 ovs agent.
 class ntnuopenstack::neutron::ovs (
   $tenant_mapping,
-  $local_ip         = undef,
-  $tunnel_types     = undef,
+  $manage_vswitch = true,
+  $local_ip       = undef,
+  $tunnel_types   = undef,
 ) {
   $connections = lookup('ntnuopenstack::neutron::external::connections', {
     'value_type'    => Hash[String, String],
@@ -21,6 +22,7 @@ class ntnuopenstack::neutron::ovs (
 
   class { '::neutron::agents::ml2::ovs':
     bridge_mappings => $mappings,
+    manage_vswitch  => $manage_vswitch,
     local_ip        => $local_ip,
     tunnel_types    => $tunnel_types,
   }

--- a/manifests/neutron/ovs.pp
+++ b/manifests/neutron/ovs.pp
@@ -6,7 +6,7 @@ class ntnuopenstack::neutron::ovs (
   $tunnel_types   = undef,
 ) {
   $connections = lookup('ntnuopenstack::neutron::external::connections', {
-    'value_type'    => Hash[String, String],
+    'value_type'    => Hash[String, Variant[String, Hash]],
     'default_value' => {},
   })
 

--- a/manifests/neutron/tenant/vlan.pp
+++ b/manifests/neutron/tenant/vlan.pp
@@ -20,6 +20,7 @@ class ntnuopenstack::neutron::tenant::vlan {
 
     class { '::ntnuopenstack::neutron::ovs':
       tenant_mapping => "physnet-vlan:${tenant_bridge}",
+      manage_vswitch => false,
     }
 
   # If the tenant-VLANS are connected to a physical if; create the bridge

--- a/manifests/neutron/tenant/vlan.pp
+++ b/manifests/neutron/tenant/vlan.pp
@@ -7,18 +7,31 @@ class ntnuopenstack::neutron::tenant::vlan {
   include ::ntnuopenstack::neutron::ml2::config
   require ::vswitch::ovs
 
+  # If the tenant-vlans are configured to be present on a VLAN, print an error.
   if($tenant_if == 'vlan') {
     $a = 'It is impossible to use a VLAN for tenant_if when using VLANs to'
     $b = 'separate tenant networks.'
     fail("${a} ${b}")
-  }
 
-  class { '::ntnuopenstack::neutron::ovs':
-    tenant_mapping => 'physnet-vlan:br-vlan',
-  }
+  # If the tenant-vlans are connected to a vswitch which already exists, connect
+  # to that vswitch.
+  } elsif ($tenant_if == 'vswitch') {
+    $tenant_bridge = lookup('ntnuopenstack::tenant::bridge')
 
-  vs_port { $tenant_if:
-    ensure => present,
-    bridge => 'br-vlan',
+    class { '::ntnuopenstack::neutron::ovs':
+      tenant_mapping => "physnet-vlan:${tenant_bridge}",
+    }
+
+  # If the tenant-VLANS are connected to a physical if; create the bridge
+  # 'br-vlan' and add the physical interface to it.
+  } else {
+    class { '::ntnuopenstack::neutron::ovs':
+      tenant_mapping => 'physnet-vlan:br-vlan',
+    }
+
+    vs_port { $tenant_if:
+      ensure => present,
+      bridge => 'br-vlan',
+    }
   }
 }


### PR DESCRIPTION
This change enables us to use a single uplink (or, a LACP link-aggregate) to connect our compute or neutronnet nodes to the network. This uplink natively carries the management-network, and all other networks are carried as VLAN's. The changes inludes:
 - Allow connecting external networks already present on an existing vswitch to openstack.
 - Allows tenant-traffic (VLAN's and VXLAN's) to pass over a pre-existing vswitch.

### Hiera changes:
 - The key `ntnuopenstack::neutron::external::connections` have a format-change. The old format is still supported, but it will be removed in the future. The new format defines external connections like so: 

```
ntnuopenstack::neutron::external::connections:
  ntnuint: 
    type: 'vswitch'
    bridge: 'infra'
    vlan: 407 
  ntnuext: 
    type: 'vswitch'
    bridge: 'infra'
    vlan: 417
```

 - If the key `profile::interfaces::tenant` is set to `vswitch` the key `ntnuopenstack::tenant::bridge` needs to contain the name of the bridge connecting the tenant VLAN's to the physical infrastructure. If VXLAN's are used it is also mandatory to have the key `ntnuopenstack::tenant::vlan` to define which VLAN carries the VXLAN tunnels.