### PR TITLE
Imageformats

### DIFF
--- a/example/hieradata/ntnuopenstack.yaml
+++ b/example/hieradata/ntnuopenstack.yaml
@@ -72,6 +72,10 @@ ntnuopenstack::endpoint::public::ipv6: "%{alias('profile::haproxy::services::ipv
 ntnuopenstack::glance::ceph::key: '<ceph-key>'
 ntnuopenstack::glance::keystone::password: '<password>'
 ntnuopenstack::glance::mysql::password: '<password>'
+ntnuopenstack::glance::disk_formats:
+  'raw': 'Raw'
+  'qcow2': 'QCOW2 - QEMU Emulator'
+  'vmdk': 'VMDK - Virtual Machine Disk'
 
 ntnuopenstack::heat::auth_encryption_key: '<password>'
 ntnuopenstack::heat::keystone::password: '<password>'

--- a/manifests/glance/api.pp
+++ b/manifests/glance/api.pp
@@ -37,6 +37,18 @@ class ntnuopenstack::glance::api {
     'default_value' => 'legacy',
   })
 
+  $disk_formats = lookup('ntnuopenstack::glance::disk_formats', {
+    'value_type'    => Array[String],
+    'default_value' => ['raw', 'qcow2'],
+  })
+  $container_formats = lookup('ntnuopenstack::glance::container_formats', {
+    'value_type'    => Array[String],
+    'default_value' => ['bare'],
+  })
+
+  $disk_formats_real = join($disk_formats, ',')
+  $container_formats_real = join($container_formats, ',')
+
   require ::ntnuopenstack::repo
   contain ::ntnuopenstack::glance::ceph
   contain ::ntnuopenstack::glance::firewall::server::api
@@ -73,7 +85,9 @@ class ntnuopenstack::glance::api {
   }
 
   glance_api_config {
-    'DEFAULT/default_store': value => 'rbd';
+    'DEFAULT/default_store':          value => 'rbd';
+    'image_format/container_formats': value => $container_formats_real;
+    'image_format/disk_formats':      value => $disk_formats_real;
   }
 
   if ($upload_mode == 'direct') {

--- a/manifests/glance/api.pp
+++ b/manifests/glance/api.pp
@@ -38,7 +38,8 @@ class ntnuopenstack::glance::api {
   })
 
   $disk_formats = lookup('ntnuopenstack::glance::disk_formats', {
-    'default_value' =>  ['raw', 'qcow2']
+    'value_type'    => Hash[String, String],
+    'default_value' => {'raw' => '', 'qcow2' => ''}
   })
   $container_formats = lookup('ntnuopenstack::glance::container_formats', {
     'value_type'    => Array[String],

--- a/manifests/glance/api.pp
+++ b/manifests/glance/api.pp
@@ -38,15 +38,14 @@ class ntnuopenstack::glance::api {
   })
 
   $disk_formats = lookup('ntnuopenstack::glance::disk_formats', {
-    'value_type'    => Array[String],
-    'default_value' => ['raw', 'qcow2'],
+    'default_value' =>  ['raw', 'qcow2']
   })
   $container_formats = lookup('ntnuopenstack::glance::container_formats', {
     'value_type'    => Array[String],
     'default_value' => ['bare'],
   })
 
-  $disk_formats_real = join($disk_formats, ',')
+  $disk_formats_real = join(keys($disk_formats), ',')
   $container_formats_real = join($container_formats, ',')
 
   require ::ntnuopenstack::repo

--- a/manifests/horizon/base.pp
+++ b/manifests/horizon/base.pp
@@ -36,6 +36,21 @@ class ntnuopenstack::horizon::base {
     'default_value' => 'legacy',
   })
 
+  $image_formats = lookup('ntnuopenstack::glance::disk_formats', {
+    'value_type'    => Hash[String, String],
+    'default_value' => { 'raw' => 'Raw', 'qcow2' => 'QCOW2 - QEMU Emulator' }
+  })
+
+  $image_formats_default = {
+    '' => 'Select format',
+  }
+
+  $image_formats_real = $image_formats_default + $image_formats
+
+  $image_backend = {
+    'image_formats' => $image_formats_real,
+  }
+
   include ::profile::services::apache::firewall
   require ::ntnuopenstack::repo
   require ::ntnuopenstack::common
@@ -75,6 +90,7 @@ class ntnuopenstack::horizon::base {
       {'name' => $ldap_name, 'display' => $description},
       {'name' => 'default',  'display' => 'Openstack accounts'},
     ],
+    image_backend                  => $image_backend,
     manage_memcache_package        => false,
     neutron_options                => {
       enable_firewall => true,


### PR DESCRIPTION
Set sane defaults for allowed disk formats in glance when using ceph. The restrictions in glance will be reflected in horizon as well.