### PR TITLE
Ussuri

### DIFF
--- a/example/hieradata/ntnuopenstack.yaml
+++ b/example/hieradata/ntnuopenstack.yaml
@@ -37,6 +37,8 @@ magnum::keystone::authtoken::www_authenticate_uri: "%{lookup('ntnuopenstack::key
 magnum::keystone::authtoken::memcached_servers: "%{alias('ntnuopenstack::keystone::memcached::servers')}"
 magnum::keystone::authtoken::password: "%{lookup('ntnuopenstack::magnum::keystone::password')}"
 magnum::keystone::authtoken::region_name: "%{lookup('ntnuopenstack::region')}"
+magnum::keystone::keystone_auth::auth_url: "%{alias('magnum::keystone::authtoken::auth_url')}"
+magnum::keystone::keystone_auth::password: "%{alias('magnum::keystone::authtoken::password')}"
 octavia::db::database_connection: "mysql+pymysql://octavia:%{lookup('ntnuopenstack::octavia::mysql::password')}@%{lookup('ntnuopenstack::nova::mysql::ip')}/octavia"
 octavia::keystone::authtoken::auth_url: "%{alias('ntnuopenstack::keystone::auth::url')}"
 octavia::keystone::authtoken::auth_uri: "%{alias('ntnuopenstack::keystone::auth::uri')}"

--- a/manifests/glance/api.pp
+++ b/manifests/glance/api.pp
@@ -30,28 +30,11 @@ class ntnuopenstack::glance::api {
     'default_value' => true,
   })
 
-  $horizon_fqdn = lookup('ntnuopenstack::horizon::server_name')
-  $horizon_url = "https://${horizon_fqdn}"
-  $upload_mode = lookup('ntnuopenstack::horizon::upload_mode', {
-    'value_type'   => Enum['legacy', 'direct', 'off'],
-    'default_value' => 'legacy',
-  })
-
-  $disk_formats = lookup('ntnuopenstack::glance::disk_formats', {
-    'value_type'    => Hash[String, String],
-    'default_value' => {'raw' => '', 'qcow2' => ''}
-  })
-  $container_formats = lookup('ntnuopenstack::glance::container_formats', {
-    'value_type'    => Array[String],
-    'default_value' => ['bare'],
-  })
-
-  $disk_formats_real = join(keys($disk_formats), ',')
-  $container_formats_real = join($container_formats, ',')
-
   require ::ntnuopenstack::repo
   contain ::ntnuopenstack::glance::ceph
   contain ::ntnuopenstack::glance::firewall::server::api
+  include ::ntnuopenstack::glance::formats
+  include ::ntnuopenstack::glance::horizon
   include ::ntnuopenstack::glance::sudo
   include ::ntnuopenstack::glance::rabbit
   include ::profile::services::memcache::pythonclient
@@ -68,9 +51,9 @@ class ntnuopenstack::glance::api {
     # ::glance::api::authtoken.
     auth_strategy                => '',
     database_connection          => $database_connection,
+    default_backend              => 'ceph-default',
+    enabled_backends             => ['ceph-default:rbd'],
     enable_proxy_headers_parsing => $confhaproxy,
-    stores                       => ['glance.store.rbd.Store'],
-    os_region_name               => $region,
     show_image_direct_url        => true,
     show_multiple_locations      => true,
     sync_db                      => $db_sync,
@@ -82,19 +65,5 @@ class ntnuopenstack::glance::api {
     www_authenticate_uri => "${keystone_public}:5000",
     memcached_servers    => $memcache,
     region_name          => $region,
-  }
-
-  glance_api_config {
-    'DEFAULT/default_store':          value => 'rbd';
-    'image_format/container_formats': value => $container_formats_real;
-    'image_format/disk_formats':      value => $disk_formats_real;
-  }
-
-  if ($upload_mode == 'direct') {
-    glance_api_config {
-      'cors/allowed_origin': value => $horizon_url;
-      'cors/max_age':        value => 3600;
-      'cors/allow_methods':  value => 'GET,PUT,POST,DELETE';
-    }
   }
 }

--- a/manifests/glance/ceph.pp
+++ b/manifests/glance/ceph.pp
@@ -20,8 +20,10 @@ class ntnuopenstack::glance::ceph {
     inject  => true,
   }
 
-  class { '::glance::backend::rbd' :
-    rbd_store_user  => 'glance',
-    manage_packages => false,
+  ::glance::backend::multistore::rbd { 'ceph-default' :
+    manage_packages   => false,
+    rbd_store_pool    => 'images',
+    rbd_store_user    => 'glance',
+    store_description => 'Default CEPH store',
   }
 }

--- a/manifests/glance/formats.pp
+++ b/manifests/glance/formats.pp
@@ -1,0 +1,19 @@
+# Defines which formats we allow in our glance API.
+class ntnuopenstack::glance::formats {
+  $disk_formats = lookup('ntnuopenstack::glance::disk_formats', {
+    'value_type'    => Hash[String, String],
+    'default_value' => {'raw' => '', 'qcow2' => ''}
+  })
+  $container_formats = lookup('ntnuopenstack::glance::container_formats', {
+    'value_type'    => Array[String],
+    'default_value' => ['bare'],
+  })
+
+  $disk_formats_real = join(keys($disk_formats), ',')
+  $container_formats_real = join($container_formats, ',')
+
+  glance_api_config {
+    'image_format/container_formats': value => $container_formats_real;
+    'image_format/disk_formats':      value => $disk_formats_real;
+  }
+}

--- a/manifests/glance/horizon.pp
+++ b/manifests/glance/horizon.pp
@@ -1,0 +1,17 @@
+# Configures glance to accept uploads directly from clients using horizon.
+class ntnuopenstack::glance::horizon {
+  $horizon_fqdn = lookup('ntnuopenstack::horizon::server_name')
+  $horizon_url = "https://${horizon_fqdn}"
+  $upload_mode = lookup('ntnuopenstack::horizon::upload_mode', {
+    'value_type'   => Enum['legacy', 'direct', 'off'],
+    'default_value' => 'legacy',
+  })
+
+  if ($upload_mode == 'direct') {
+    glance_api_config {
+      'cors/allowed_origin': value => $horizon_url;
+      'cors/max_age':        value => 3600;
+      'cors/allow_methods':  value => 'GET,PUT,POST,DELETE';
+    }
+  }
+}

--- a/manifests/glance/horizon.pp
+++ b/manifests/glance/horizon.pp
@@ -9,9 +9,9 @@ class ntnuopenstack::glance::horizon {
 
   if ($upload_mode == 'direct') {
     glance_api_config {
+      'cors/allow_methods':  value => 'GET,PUT,POST,DELETE';
       'cors/allowed_origin': value => $horizon_url;
       'cors/max_age':        value => 3600;
-      'cors/allow_methods':  value => 'GET,PUT,POST,DELETE';
     }
   }
 }

--- a/manifests/heat/base.pp
+++ b/manifests/heat/base.pp
@@ -6,15 +6,6 @@ class ntnuopenstack::heat::base {
   $keystone_internal = lookup('ntnuopenstack::keystone::endpoint::internal', Stdlib::Httpurl)
   $db_sync = lookup('ntnuopenstack::heat::db::sync', Boolean)
 
-  # Memcached servers
-  $cache_servers = lookup('profile::memcache::servers', {
-    'value_type'    => Array[String],
-    'merge'         => 'unique',
-  })
-  $memcache = $cache_servers.map | $server | {
-    "${server}:11211"
-  }
-
   # Rabbitmq servers
   $transport_url = lookup('ntnuopenstack::transport::url', String)
   $rabbitservers = lookup('profile::rabbitmq::servers', {
@@ -27,6 +18,7 @@ class ntnuopenstack::heat::base {
   $mysql_ip = lookup('ntnuopenstack::heat::mysql::ip', Stdlib::IP::Address)
   $database_connection = "mysql+pymysql://heat:${mysql_pass}@${mysql_ip}/heat"
 
+  include ::ntnuopenstack::heat::cache
   require ::ntnuopenstack::repo
 
   if ($rabbitservers) {

--- a/manifests/heat/cache.pp
+++ b/manifests/heat/cache.pp
@@ -1,0 +1,16 @@
+# Configures heat to use memcache
+class ntnuopenstack::heat::cache {
+  $cache_servers = lookup('profile::memcache::servers', {
+    'value_type'    => Array[String],
+    'merge'         => 'unique',
+  })
+  $memcache_servers = $cache_servers.map | $server | {
+    "${server}:11211"
+  }
+
+  class { '::heat::cache':
+    backend          => 'oslo_cache.memcache_pool',
+    enabled          => true,
+    memcache_servers => $memcache_servers,
+  }
+}

--- a/manifests/keystone/base.pp
+++ b/manifests/keystone/base.pp
@@ -2,12 +2,10 @@
 class ntnuopenstack::keystone::base {
   $region = lookup('ntnuopenstack::region', String)
 
-  $admin_endpoint  = lookup('ntnuopenstack::keystone::endpoint::admin', Stdlib::Httpurl)
-  $public_endpoint = lookup('ntnuopenstack::keystone::endpoint::public', Stdlib::Httpurl)
-
-  $admin_email = lookup('ntnuopenstack::keystone::admin_email', String)
-  $admin_pass  = lookup('ntnuopenstack::keystone::admin_password', String)
-  $admin_token = lookup('ntnuopenstack::keystone::admin_token', String)
+  $admin_endpoint  = lookup('ntnuopenstack::keystone::endpoint::admin',
+                              Stdlib::Httpurl)
+  $public_endpoint = lookup('ntnuopenstack::keystone::endpoint::public',
+                              Stdlib::Httpurl)
 
   $mysql_password = lookup('ntnuopenstack::keystone::mysql::password', String)
   $mysql_ip = lookup('ntnuopenstack::keystone::mysql::ip', Stdlib::IP::Address)
@@ -40,6 +38,7 @@ class ntnuopenstack::keystone::base {
   })
 
   require ::ntnuopenstack::repo
+  include ::ntnuopenstack::keystone::bootstrap
 
   if($cache_servers) {
     $memcache = $cache_servers.map | $server | {
@@ -63,8 +62,6 @@ class ntnuopenstack::keystone::base {
   }
 
   class { '::keystone':
-    admin_token                  => $admin_token,
-    admin_password               => $admin_pass,
     database_connection          => $db_con,
     enabled                      => false,
     service_name                 => 'httpd',
@@ -80,13 +77,6 @@ class ntnuopenstack::keystone::base {
     token_expiration             => $token_expiration,
     sync_db                      => $sync_db,
     *                            => $keystone_opts,
-  }
-
-  class { '::keystone::roles::admin':
-    email        => $admin_email,
-    password     => $admin_pass,
-    admin_tenant => 'admin',
-    require      => Class['::keystone'],
   }
 
   class { '::keystone::wsgi::apache':

--- a/manifests/keystone/bootstrap.pp
+++ b/manifests/keystone/bootstrap.pp
@@ -1,0 +1,22 @@
+# Bootstraps our keystone-installation with admin-user and endpoint. 
+class ntnuopenstack::keystone::bootstrap {
+  $email = lookup('ntnuopenstack::keystone::admin_email', String)
+  $password  = lookup('ntnuopenstack::keystone::admin_password', String)
+
+  $admin    = lookup('ntnuopenstack::keystone::endpoint::admin',
+                                Stdlib::Httpurl)
+  $internal = lookup('ntnuopenstack::keystone::endpoint::internal',
+                                Stdlib::Httpurl)
+  $public   = lookup('ntnuopenstack::keystone::endpoint::public',
+                                Stdlib::Httpurl)
+  $region   = lookup('ntnuopenstack::region', String)
+
+  class { '::keystone::bootstrap':
+    email        => $email,
+    password     => $password,
+    admin_url    => "${admin}:5000",
+    internal_url => "${internal}:5000",
+    public_url   => "${public}:5000",
+    region       => $region,
+  }
+}

--- a/manifests/keystone/cache.pp
+++ b/manifests/keystone/cache.pp
@@ -1,0 +1,21 @@
+# Configures cache for keystone
+class ntnuopenstack::keystone::cache {
+  $cache_servers = lookup('profile::memcache::servers', {
+    'value_type'    => Variant[Array[String], Boolean],
+    'default_value' => false,
+    'merge'         => 'unique',
+  })
+
+  if($cache_servers) {
+    $memcache_servers = $cache_servers.map | $server | {
+      "${server}:11211"
+    }
+
+    class { '::keystone::cache':
+      backend          => 'oslo_cache.memcache_pool',
+      enabled          => true,
+      memcache_servers => $memcache_servers,
+      token_caching    => true,
+    }
+  }
+}

--- a/manifests/keystone/endpoint.pp
+++ b/manifests/keystone/endpoint.pp
@@ -28,6 +28,8 @@ class ntnuopenstack::keystone::endpoint {
     'value_type'    => Variant[Boolean, String],
   })
 
+  include ::ntnuopenstack::keystone::bootstrap
+
   # We need to define the endpoints on the keystone hosts, so include the other
   # endpoints here.
   include ::ntnuopenstack::cinder::endpoint
@@ -62,13 +64,5 @@ class ntnuopenstack::keystone::endpoint {
   if($magnum) {
     include ::ntnuopenstack::magnum::endpoint
     include ::ntnuopenstack::magnum::domain
-  }
-  # Defining the keystone endpoint
-  class { '::keystone::endpoint':
-    public_url   => "${public_endpoint}:5000",
-    admin_url    => "${admin_endpoint}:5000",
-    internal_url => "${internal_endpoint}:5000",
-    region       => $region,
-    require      => Class['::keystone'],
   }
 }

--- a/manifests/magnum/api.pp
+++ b/manifests/magnum/api.pp
@@ -33,7 +33,7 @@ class ntnuopenstack::magnum::api {
     'keystone_auth/auth_url'            : value => $auth_url;
     'keystone_auth/username'            : value => 'magnum';
     'keystone_auth/password'            : value => $password, secret => true;
-    'keystone_auth/project_name'        : value => 'Default';
+    'keystone_auth/project_name'        : value => 'services';
     'keystone_auth/project_domain_name' : value => 'Default';
     'keystone_auth/user_domain_name'    : value => 'Default';
   }

--- a/manifests/magnum/api.pp
+++ b/manifests/magnum/api.pp
@@ -23,18 +23,4 @@ class ntnuopenstack::magnum::api {
     ssl               => false,
     access_log_format => 'forwarded',
   }
-
-  # This is a temporary hack while wait for a fix for this bug:
-  #https://bugs.launchpad.net/puppet-magnum/+bug/1900813
-  $auth_url = lookup('magnum::keystone::authtoken::auth_url')
-  $password = lookup('magnum::keystone::authtoken::password')
-
-  magnum_config {
-    'keystone_auth/auth_url'            : value => $auth_url;
-    'keystone_auth/username'            : value => 'magnum';
-    'keystone_auth/password'            : value => $password, secret => true;
-    'keystone_auth/project_name'        : value => 'services';
-    'keystone_auth/project_domain_name' : value => 'Default';
-    'keystone_auth/user_domain_name'    : value => 'Default';
-  }
 }

--- a/manifests/magnum/api.pp
+++ b/manifests/magnum/api.pp
@@ -23,4 +23,18 @@ class ntnuopenstack::magnum::api {
     ssl               => false,
     access_log_format => 'forwarded',
   }
+
+  # This is a temporary hack while wait for a fix for this bug:
+  #https://bugs.launchpad.net/puppet-magnum/+bug/1900813
+  $auth_url = lookup('magnum::keystone::authtoken::auth_url')
+  $password = lookup('magnum::keystone::authtoken::password')
+
+  magnum_config {
+    'keystone_auth/auth_url'            : value => $auth_url;
+    'keystone_auth/username'            : value => 'magnum';
+    'keystone_auth/password'            : value => $password, secret => true;
+    'keystone_auth/project_name'        : value => 'Default';
+    'keystone_auth/project_domain_name' : value => 'Default';
+    'keystone_auth/user_domain_name'    : value => 'Default';
+  }
 }

--- a/manifests/magnum/base.pp
+++ b/manifests/magnum/base.pp
@@ -16,6 +16,7 @@ class ntnuopenstack::magnum::base {
   }
 
   $transport_url = lookup('ntnuopenstack::transport::url')
+  $region = lookup('ntnuopenstack::region', String)
 
   require ::ntnuopenstack::repo
   include ::ntnuopenstack::magnum::params
@@ -33,11 +34,12 @@ class ntnuopenstack::magnum::base {
   }
 
   class { '::magnum::keystone::domain':
-    cluster_user_trust => true,
-    manage_domain      => false,
-    manage_user        => false,
-    manage_role        => false,
-    domain_password    => $domain_password,
+    cluster_user_trust   => true,
+    manage_domain        => false,
+    manage_user          => false,
+    manage_role          => false,
+    domain_password      => $domain_password,
+    keystone_region_name => $region,
   }
 
   magnum_config {

--- a/manifests/magnum/clients.pp
+++ b/manifests/magnum/clients.pp
@@ -2,25 +2,7 @@
 class ntnuopenstack::magnum::clients {
   $region = lookup('ntnuopenstack::region', String)
 
-  class { '::magnum::clients::barbican':
-    region_name => $region,
-  }
-  class { '::magnum::clients::cinder':
-    region_name => $region,
-  }
-  class { '::magnum::clients::glance':
-    region_name => $region,
-  }
-  class { '::magnum::clients::heat':
-    region_name => $region,
-  }
-  class { '::magnum::clients::magnum':
-    region_name => $region,
-  }
-  class { '::magnum::clients::neutron':
-    region_name => $region,
-  }
-  class { '::magnum::clients::nova':
+  class { '::magnum::clients':
     region_name => $region,
   }
 

--- a/manifests/neutron/network.pp
+++ b/manifests/neutron/network.pp
@@ -5,6 +5,7 @@ class ntnuopenstack::neutron::network {
   contain ::ntnuopenstack::neutron::agents
   contain ::ntnuopenstack::neutron::external
   contain ::ntnuopenstack::neutron::firewall::l3agent
+  include ::ntnuopenstack::neutron::nolbaas
   contain ::ntnuopenstack::neutron::services
   contain ::ntnuopenstack::neutron::tenant
   contain ::profile::monitoring::munin::plugin::openstack::neutronnet

--- a/manifests/neutron/nolbaas.pp
+++ b/manifests/neutron/nolbaas.pp
@@ -1,0 +1,9 @@
+# Uninstalls old neutron lbaas packages
+class ntnuopenstack::neutron::nolbaas {
+  package { [
+      'neutron-lbaas-common',
+      'neutron-lbaasv2-agent',
+      'python3-neutron-lbaas', ] :
+    ensure => 'absent',
+  }
+}

--- a/manifests/nova/base.pp
+++ b/manifests/nova/base.pp
@@ -23,7 +23,6 @@ class ntnuopenstack::nova::base {
   $region = lookup('ntnuopenstack::region')
   $placement_password = lookup('ntnuopenstack::nova::placement::keystone::password')
   $keystone_admin = lookup('ntnuopenstack::endpoint::admin')
-  $internal_endpoint = lookup('ntnuopenstack::endpoint::internal')
 
   # RabbitMQ connection-information
   $rabbitservers = lookup('profile::rabbitmq::servers', {
@@ -49,8 +48,6 @@ class ntnuopenstack::nova::base {
     database_connection     => $db_con,
     default_transport_url   => $transport_url,
     api_database_connection => $api_db_con,
-    image_service           => 'nova.image.glance.GlanceImageService',
-    glance_api_servers      => "${internal_endpoint}:9292",
     *                       => $ha_transport_conf,
   }
 

--- a/manifests/nova/base/compute.pp
+++ b/manifests/nova/base/compute.pp
@@ -32,7 +32,6 @@ class ntnuopenstack::nova::base::compute {
   class { '::nova':
     database_connection           => $database_connection,
     default_transport_url         => $transport_url,
-    glance_api_servers            => "${internal_endpoint}:9292",
     block_device_allocate_retries => 120,
     *                             => $ha_transport_conf,
   }

--- a/manifests/nova/neutron.pp
+++ b/manifests/nova/neutron.pp
@@ -16,11 +16,9 @@ class ntnuopenstack::nova::neutron {
   require ::ntnuopenstack::repo
 
   class { '::nova::network::neutron':
+    auth_url              => "${keystone_internal}:5000/v3",
     default_floating_pool => $floating_pool,
-    neutron_region_name   => $region,
-    neutron_password      => $neutron_password,
-    neutron_auth_url      => "${keystone_internal}:5000/v3",
-    vif_plugging_is_fatal => false,
-    vif_plugging_timeout  => '0',
+    password              => $neutron_password,
+    region_name           => $region,
   }
 }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -12,6 +12,7 @@ class ntnuopenstack::repo {
       }
     }
   } elsif ($::osfamily == 'RedHat') {
+    include ::profile::repo::powertools
     class { '::openstack_extras::repo::redhat::redhat':
       package_require => true,
     }


### PR DESCRIPTION
Changes needed for our ussuri-upgrades, and some general improvements:
 - Re-structure the glance-classes
 - Use the now mandatory glance multistore config
 - Separate cache-classes for heat and keystone
 - Deprecate the keystone auth-token
 - Removed neutron-lbaas
 - Include the centOS PowerTools repo

Requires profile v1.16.2