### PR TITLE
Cinderpools

### DIFF
--- a/manifests/cinder/api.pp
+++ b/manifests/cinder/api.pp
@@ -5,6 +5,10 @@ class ntnuopenstack::cinder::api {
     'value_type'    => Boolean,
   })
   $db_sync = lookup('ntnuopenstack::cinder::db::sync', Boolean)
+  $default_type = lookup('ntnuopenstack::cinder::type::default', {
+    'value_type'    => String,
+    'default_value' => 'Normal',
+  })
 
   require ::ntnuopenstack::repo
   require ::ntnuopenstack::cinder::base
@@ -21,7 +25,7 @@ class ntnuopenstack::cinder::api {
   class { '::cinder::api':
     enabled                      => false,
     service_name                 => 'httpd',
-    default_volume_type          => 'Normal',
+    default_volume_type          => $default_type,
     enable_proxy_headers_parsing => $confhaproxy,
     sync_db                      => $db_sync,
   }

--- a/manifests/cinder/ceph.pp
+++ b/manifests/cinder/ceph.pp
@@ -3,6 +3,19 @@
 class ntnuopenstack::cinder::ceph {
   $ceph_key = lookup('ntnuopenstack::cinder::ceph::key', String)
 
+  $backends = lookup('ntnuopenstack::cinder::rbd::backends', {
+    'value_type'    => Hash[String, String],
+    'default_value' => {
+      'rbd-images' => 'volumes',
+    },
+  })
+
+  $volumes = $backends.values().unique
+  $poolaccess = $volumes.map | $pool | {
+    "allow rwx pool=${pool}"
+  }
+  $poolaccessstr = $poolaccess.join(', ')
+
   require ::profile::ceph::client
 
   ceph_config {
@@ -12,8 +25,7 @@ class ntnuopenstack::cinder::ceph {
   ceph::key { 'client.cinder':
     secret  => $ceph_key,
     cap_mon => 'allow r, allow command "osd blacklist"',
-    cap_osd =>
-      'allow class-read object_prefix rbd_children, allow rwx pool=volumes',
+    cap_osd => "allow class-read object_prefix rbd_children, ${poolaccessstr}",
     inject  => true,
   }
 }

--- a/manifests/cinder/ceph.pp
+++ b/manifests/cinder/ceph.pp
@@ -10,8 +10,8 @@ class ntnuopenstack::cinder::ceph {
     },
   })
 
-  $volumes = $backends.values().unique
-  $poolaccess = $volumes.map | $pool | {
+  $pools = $backends.values().unique
+  $poolaccess = $pools.map | $pool | {
     "allow rwx pool=${pool}"
   }
   $poolaccessstr = $poolaccess.join(', ')

--- a/manifests/cinder/volume.pp
+++ b/manifests/cinder/volume.pp
@@ -40,12 +40,15 @@ class ntnuopenstack::cinder::volume {
 
   $types.each | $typename, $data | {
     $backend = $data['backend']
+
+    $props = pick($data['properties'], {}).map | $key, $value | {
+      "${key}=${value}"
+    }
+
     cinder_type { $typename :
       ensure     => pick($data['ensure'], present),
       is_public  => pick($data['public'], true),
-      properties => [
-        "volume_backend_name=${backend}"
-      ],
+      properties => concat([ "volume_backend_name=${backend}" ], $props),
     }
   }
 }

--- a/manifests/cinder/volume.pp
+++ b/manifests/cinder/volume.pp
@@ -11,7 +11,7 @@ class ntnuopenstack::cinder::volume {
   })
 
   $types = lookup('ntnuopenstack::cinder::types', {
-    'value_type'    => Hash[String, Hash[String, String]],
+    'value_type'    => Hash[String, Hash[String, Variant[String, Hash]],
     'default_value' => {
       'Normal'      => {
         'backend' => 'rbd-images',

--- a/manifests/cinder/volume.pp
+++ b/manifests/cinder/volume.pp
@@ -11,7 +11,7 @@ class ntnuopenstack::cinder::volume {
   })
 
   $types = lookup('ntnuopenstack::cinder::types', {
-    'value_type'    => Hash[String, Hash[String, Variant[String, Hash]],
+    'value_type'    => Hash[String, Hash[String, Variant[String, Hash]]],
     'default_value' => {
       'Normal'      => {
         'backend' => 'rbd-images',

--- a/manifests/cinder/volume.pp
+++ b/manifests/cinder/volume.pp
@@ -3,6 +3,22 @@
 class ntnuopenstack::cinder::volume {
   $ceph_uuid = lookup('ntnuopenstack::nova::ceph::uuid', String)
 
+  $backends = lookup('ntnuopenstack::cinder::rbd::backends', {
+    'value_type'    => Hash[String, String],
+    'default_value' => {
+      'rbd-images' => 'volumes',
+    },
+  })
+
+  $types = lookup('ntnuopenstack::cinder::types', {
+    'value_type'    => Hash[String, Hash[String, String]],
+    'default_value' => {
+      'Normal'      => {
+        'backend' => 'rbd-images',
+      },
+    },
+  })
+
   require ::ntnuopenstack::repo
   require ::ntnuopenstack::clients
   require ::ntnuopenstack::cinder::base
@@ -10,38 +26,26 @@ class ntnuopenstack::cinder::volume {
 
   class { '::cinder::volume': }
 
-  cinder::backend::rbd {'rbd-images':
-    rbd_pool        => 'volumes',
-    rbd_user        => 'nova',
-    rbd_secret_uuid => $ceph_uuid,
-  }
-
-  cinder_type {'Slow':
-    ensure     => present,
-    properties => ['volume_backend_name=rbd-images'],
-  }
-
-  cinder_type {'Normal':
-    ensure     => present,
-    properties => ['volume_backend_name=rbd-images'],
-  }
-
-  cinder_type {'Fast':
-    ensure     => present,
-    properties => ['volume_backend_name=rbd-images'],
-  }
-
-  cinder_type {'VeryFast':
-    ensure     => present,
-    properties => ['volume_backend_name=rbd-images'],
-  }
-
-  cinder_type {'Unlimited':
-    ensure     => present,
-    properties => ['volume_backend_name=rbd-images'],
-  }
-
   class { 'cinder::backends':
-    enabled_backends => ['rbd-images']
+    enabled_backends => $backends.keys(),
+  }
+
+  $backends.each | $bname, $pool | {
+    cinder::backend::rbd { $bname :
+      rbd_pool        => $pool,
+      rbd_user        => 'nova',
+      rbd_secret_uuid => $ceph_uuid,
+    }
+  }
+
+  $types.each | $typename, $data | {
+    $backend = $data['backend']
+    cinder_type { $typename :
+      ensure     => pick($data['ensure'], present),
+      is_public  => pick($data['public'], true),
+      properties => [
+        "volume_backend_name=${backend}"
+      ],
+    }
   }
 }

--- a/manifests/nova/ceph.pp
+++ b/manifests/nova/ceph.pp
@@ -4,6 +4,19 @@ class ntnuopenstack::nova::ceph {
 
   $nova_key = lookup('ntnuopenstack::cinder::ceph::key')
 
+  $backends = lookup('ntnuopenstack::cinder::rbd::backends', {
+    'value_type'    => Hash[String, String],
+    'default_value' => {
+      'rbd-images' => 'volumes',
+    },
+  })
+
+  $volumes = $backends.values().unique
+  $poolaccess = $volumes.map | $pool | {
+    "allow rwx pool=${pool}"
+  }
+
+
   exec { '/usr/bin/ceph osd pool create volumes 32' :
     unless => '/usr/bin/ceph osd pool get volumes size',
   }
@@ -13,12 +26,12 @@ class ntnuopenstack::nova::ceph {
   }
 
   $top = 'allow class-read object_prefix rbd_children'
-  $volumes = 'allow rwx pool=volumes'
+  $volumes = $poolaccess.join(', ')
   $images = 'allow rwx pool=images'
   ceph::key { 'client.nova':
     secret  => $nova_key,
     cap_mon => 'allow r, allow command "osd blacklist"',
-    cap_osd => "${top},${volumes}, ${images}",
+    cap_osd => "${top}, ${volumes}, ${images}",
     inject  => true,
   }
 }

--- a/manifests/nova/ceph.pp
+++ b/manifests/nova/ceph.pp
@@ -11,14 +11,9 @@ class ntnuopenstack::nova::ceph {
     },
   })
 
-  $volumes = $backends.values().unique
-  $poolaccess = $volumes.map | $pool | {
+  $pools = $backends.values().unique
+  $poolaccess = $pools.map | $pool | {
     "allow rwx pool=${pool}"
-  }
-
-
-  exec { '/usr/bin/ceph osd pool create volumes 32' :
-    unless => '/usr/bin/ceph osd pool get volumes size',
   }
 
   ceph_config {


### PR DESCRIPTION
### New
 - Possibility to define cinder volume-types in hiera
 - Possibility to have multiple rbd-backends for cinder; allowing some volume-types to be assigned to other ceph pools.

### Hiera

```
ntnuopenstack::cinder::rbd::backends:
  rbd-images: 'volumes'
  rbd-hdds: 'hdd'
ntnuopenstack::cinder::types:
  Normal:
    backend: 'rbd-images'
  HDD:
    backend: 'rbd-hdds'
```