### PR TITLE
Stop using removed parameters in rgw class

### DIFF
--- a/manifests/swift/radosgw.pp
+++ b/manifests/swift/radosgw.pp
@@ -12,13 +12,11 @@ class ntnuopenstack::swift::radosgw {
 
   ::ceph::rgw::keystone { 'radosgw.main':
     rgw_keystone_url            => "${endpoint_internal}:5000",
-    rgw_keystone_version        => 'v3',
     rgw_keystone_accepted_roles => '_member_ admin',
     rgw_keystone_admin_domain   => 'Default',
     rgw_keystone_admin_project  => 'services',
     rgw_keystone_admin_user     => 'swift',
     rgw_keystone_admin_password => $keystone_password,
-    use_pki                     => false,
   }
 
   ceph_config {


### PR DESCRIPTION
Some parmateres are removed from ceph::rgw::keystone in the modern puppet-ceph module. Might be a good idea to stop using them.