### PR TITLE
New radosgw names

### DIFF
--- a/manifests/swift/ceph.pp
+++ b/manifests/swift/ceph.pp
@@ -2,13 +2,15 @@
 class ntnuopenstack::swift::ceph {
   $cephx_key = lookup('ntnuopenstack::swift::ceph::key', String)
 
+  $hostname = $trusted['hostname']
+
   require ::profile::ceph::client
 
   ceph_config {
-      'client.radosgw.main/key': value => $cephx_key;
+      "client.radosgw.${hostname}/key": value => $cephx_key;
   }
 
-  ceph::key { 'client.radosgw.main':
+  ceph::key { "client.radosgw.${hostname}":
     secret  => $cephx_key,
     cap_mon => 'allow rwx',
     cap_osd => 'allow rwx',

--- a/manifests/swift/radosgw.pp
+++ b/manifests/swift/radosgw.pp
@@ -4,13 +4,15 @@ class ntnuopenstack::swift::radosgw {
   $keystone_password = lookup('ntnuopenstack::swift::keystone::password')
   $swift_dns_name = lookup('ntnuopenstack::swift::dns::name')
 
-  ::ceph::rgw { 'radosgw.main':
+  $hostname = $trusted['hostname']
+
+  ::ceph::rgw { "radosgw.${hostname}":
     pkg_radosgw  => 'radosgw',
     rgw_dns_name => $swift_dns_name,
     user         => 'www-data',
   }
 
-  ::ceph::rgw::keystone { 'radosgw.main':
+  ::ceph::rgw::keystone { "radosgw.${hostname}":
     rgw_keystone_url            => "${endpoint_internal}:5000",
     rgw_keystone_version        => 'v3',
     rgw_keystone_accepted_roles => '_member_ admin',
@@ -22,6 +24,6 @@ class ntnuopenstack::swift::radosgw {
   }
 
   ceph_config {
-    'client.radosgw.main/rgw swift account in url': value => true;
+    "client.radosgw.${hostname}/rgw swift account in url": value => true;
   }
 }

--- a/manifests/swift/radosgw.pp
+++ b/manifests/swift/radosgw.pp
@@ -12,11 +12,6 @@ class ntnuopenstack::swift::radosgw {
     user         => 'www-data',
   }
 
-  ::ceph::rgw { 'radosgw.main':
-    rgw_ensure => 'stopped',
-    rgw_enable => false,
-  }
-
   ::ceph::rgw::keystone { "radosgw.${hostname}":
     rgw_keystone_url            => "${endpoint_internal}:5000",
     rgw_keystone_version        => 'v3',

--- a/manifests/swift/radosgw.pp
+++ b/manifests/swift/radosgw.pp
@@ -12,6 +12,11 @@ class ntnuopenstack::swift::radosgw {
     user         => 'www-data',
   }
 
+  ::ceph::rgw { 'radosgw.main':
+    rgw_ensure => 'stopped',
+    rgw_enable => false,
+  }
+
   ::ceph::rgw::keystone { "radosgw.${hostname}":
     rgw_keystone_url            => "${endpoint_internal}:5000",
     rgw_keystone_version        => 'v3',


### PR DESCRIPTION
To make sure ceph understands that there are multiple radosgw's we include the rgw's hostname in its name.