### PR TITLE
Cinder retype fix

### DIFF
--- a/manifests/cinder/ceph.pp
+++ b/manifests/cinder/ceph.pp
@@ -19,7 +19,7 @@ class ntnuopenstack::cinder::ceph {
   require ::profile::ceph::client
 
   ceph_config {
-    'client.nova/key': value => $ceph_key;
+    'client.cinder/key': value => $ceph_key;
   }
 
   ceph::key { 'client.cinder':
@@ -27,5 +27,7 @@ class ntnuopenstack::cinder::ceph {
     cap_mon => 'allow r, allow command "osd blacklist"',
     cap_osd => "allow class-read object_prefix rbd_children, ${poolaccessstr}",
     inject  => true,
+    group   => 'cinder',
+    mode    => 0640,
   }
 }

--- a/manifests/cinder/ceph.pp
+++ b/manifests/cinder/ceph.pp
@@ -28,6 +28,6 @@ class ntnuopenstack::cinder::ceph {
     cap_osd => "allow class-read object_prefix rbd_children, ${poolaccessstr}",
     inject  => true,
     group   => 'cinder',
-    mode    => 0640,
+    mode    => '0640',
   }
 }

--- a/manifests/cinder/volume.pp
+++ b/manifests/cinder/volume.pp
@@ -33,7 +33,7 @@ class ntnuopenstack::cinder::volume {
   $backends.each | $bname, $pool | {
     cinder::backend::rbd { $bname :
       rbd_pool        => $pool,
-      rbd_user        => 'nova',
+      rbd_user        => 'cinder',
       rbd_secret_uuid => $ceph_uuid,
     }
   }


### PR DESCRIPTION
Cinder retype did not work because all pools was set to rbd_user: 'nova', and the keyring-file for nova was not existing. Change the ceph config to use the cinder key instead, and configure the pools to use rbd_user: 'cinder'. 

In addition, manually make sure python3-os-brick is >= 3.0.1-0ubuntu1.3~cloud0