### PR TITLE
Fix ceph permissions for cinder

### DIFF
--- a/manifests/cinder/ceph.pp
+++ b/manifests/cinder/ceph.pp
@@ -15,7 +15,7 @@ class ntnuopenstack::cinder::ceph {
     "allow rwx pool=${pool}"
   }
   $poolaccessstr = $poolaccess.join(', ')
-  $images = 'allow r pool=images'
+  $images = 'allow rwx pool=images'
 
   require ::profile::ceph::client
 

--- a/manifests/cinder/ceph.pp
+++ b/manifests/cinder/ceph.pp
@@ -15,6 +15,7 @@ class ntnuopenstack::cinder::ceph {
     "allow rwx pool=${pool}"
   }
   $poolaccessstr = $poolaccess.join(', ')
+  $images = 'allow r pool=images'
 
   require ::profile::ceph::client
 
@@ -25,7 +26,7 @@ class ntnuopenstack::cinder::ceph {
   ceph::key { 'client.cinder':
     secret  => $ceph_key,
     cap_mon => 'allow r, allow command "osd blacklist"',
-    cap_osd => "allow class-read object_prefix rbd_children, ${poolaccessstr}",
+    cap_osd => "allow class-read object_prefix rbd_children, ${poolaccessstr}, ${images}",
     inject  => true,
     group   => 'cinder',
     mode    => '0640',


### PR DESCRIPTION
Cinder needs permissions in the images pool to be able to efficiently boot from a volume