### PR TITLE
Refactor haproxy backends

### DIFF
--- a/manifests/barbican/haproxy/backend.pp
+++ b/manifests/barbican/haproxy/backend.pp
@@ -1,31 +1,18 @@
 # Configures the haproxy backends for barbican
 class ntnuopenstack::barbican::haproxy::backend {
   $if = lookup('profile::interfaces::management')
-  $ip = $::facts['networking']['interfaces'][$if]['ip']
 
-  profile::services::haproxy::tools::register { "BarbicanPublic-${::hostname}":
-    servername  => $::hostname,
-    backendname => 'bk_barbican_public',
+  ::profile::services::haproxy::backend { 'BarbicanPublic':
+    backend   => 'bk_barbican_public',
+    port      => 9311,
+    interface => $if,
+    options   => 'check inter 2000 rise 2 fall 5',
   }
 
-  @@haproxy::balancermember { "barbican-public-${::fqdn}":
-    listening_service => 'bk_barbican_public',
-    server_names      => $::hostname,
-    ipaddresses       => $ip,
-    ports             => '9311',
-    options           => 'check inter 2000 rise 2 fall 5',
-  }
-
-  profile::services::haproxy::tools::register { "BarbicanAdmin-${::hostname}":
-    servername  => $::hostname,
-    backendname => 'bk_barbican_admin',
-  }
-
-  @@haproxy::balancermember { "barbican-admin-${::fqdn}":
-    listening_service => 'bk_barbican_admin',
-    server_names      => $::hostname,
-    ipaddresses       => $ip,
-    ports             => '9311',
-    options           => 'check inter 2000 rise 2 fall 5',
+  ::profile::services::haproxy::backend { 'BarbicanAdmin':
+    backend   => 'bk_barbican_admin',
+    port      => 9311,
+    interface => $if,
+    options   => 'check inter 2000 rise 2 fall 5',
   }
 }

--- a/manifests/cinder/haproxy/backend.pp
+++ b/manifests/cinder/haproxy/backend.pp
@@ -1,31 +1,18 @@
 # Configures the haproxy backends for cinder
 class ntnuopenstack::cinder::haproxy::backend {
   $if = lookup('profile::interfaces::management')
-  $ip = $::facts['networking']['interfaces'][$if]['ip']
 
-  profile::services::haproxy::tools::register { "CinderPublic-${::hostname}":
-    servername  => $::hostname,
-    backendname => 'bk_cinder_public',
+  ::profile::services::haproxy::backend { 'CinderPublic':
+    backend   => 'bk_cinder_public',
+    port      => 8776,
+    interface => $if,
+    options   => 'check inter 2000 rise 2 fall 5',
   }
 
-  @@haproxy::balancermember { "cinder-public-${::fqdn}":
-    listening_service => 'bk_cinder_public',
-    server_names      => $::hostname,
-    ipaddresses       => $ip,
-    ports             => '8776',
-    options           => 'check inter 2000 rise 2 fall 5',
-  }
-
-  profile::services::haproxy::tools::register { "CinderAdmin-${::hostname}":
-    servername  => $::hostname,
-    backendname => 'bk_cinder_api_admin',
-  }
-
-  @@haproxy::balancermember { "cinder-admin-${::fqdn}":
-    listening_service => 'bk_cinder_api_admin',
-    server_names      => $::hostname,
-    ipaddresses       => $ip,
-    ports             => '8776',
-    options           => 'check inter 2000 rise 2 fall 5',
+  ::profile::services::haproxy::backend { 'CinderAdmin':
+    backend   => 'bk_cinder_api_admin',
+    port      => 8776,
+    interface => $if,
+    options   => 'check inter 2000 rise 2 fall 5',
   }
 }

--- a/manifests/glance/haproxy/backend.pp
+++ b/manifests/glance/haproxy/backend.pp
@@ -1,31 +1,18 @@
 # Configures the haproxy backends for glance
 class ntnuopenstack::glance::haproxy::backend {
   $if = lookup('profile::interfaces::management')
-  $ip = $::facts['networking']['interfaces'][$if]['ip']
 
-  profile::services::haproxy::tools::register { "GlancePublic-${::hostname}":
-    servername  => $::hostname,
-    backendname => 'bk_glance_public',
+  ::profile::services::haproxy::backend { 'GlancePublic':
+    backend   => 'bk_glance_public',
+    port      => 9292,
+    interface => $if,
+    options   => 'check inter 2000 rise 2 fall 5',
   }
 
-  @@haproxy::balancermember { "glance-public-${::fqdn}":
-    listening_service => 'bk_glance_public',
-    server_names      => $::hostname,
-    ipaddresses       => $ip,
-    ports             => '9292',
-    options           => 'check inter 2000 rise 2 fall 5',
-  }
-
-  profile::services::haproxy::tools::register { "GlanceAdmin-${::hostname}":
-    servername  => $::hostname,
-    backendname => 'bk_glance_api_admin',
-  }
-
-  @@haproxy::balancermember { "glance-admin-${::fqdn}":
-    listening_service => 'bk_glance_api_admin',
-    server_names      => $::hostname,
-    ipaddresses       => $ip,
-    ports             => '9292',
-    options           => 'check inter 2000 rise 2 fall 5',
+  ::profile::services::haproxy::backend { 'GlanceAdmin':
+    backend   => 'bk_glance_api_admin',
+    port      => 9292,
+    interface => $if,
+    options   => 'check inter 2000 rise 2 fall 5',
   }
 }

--- a/manifests/heat/haproxy/backend.pp
+++ b/manifests/heat/haproxy/backend.pp
@@ -1,57 +1,32 @@
 # Configures the haproxy backends for heat
 class ntnuopenstack::heat::haproxy::backend {
   $if = lookup('profile::interfaces::management')
-  $ip = $::facts['networking']['interfaces'][$if]['ip']
 
-  profile::services::haproxy::tools::register { "HeatPublic-${::hostname}":
-    servername  => $::hostname,
-    backendname => 'bk_heat_public',
+  ::profile::services::haproxy::backend { 'HeatPublic':
+    backend   => 'bk_heat_public',
+    port      => 8004,
+    interface => $if,
+    options   => 'check inter 2000 rise 2 fall 5',
   }
 
-  @@haproxy::balancermember { "heat-public-${::fqdn}":
-    listening_service => 'bk_heat_public',
-    server_names      => $::hostname,
-    ipaddresses       => $ip,
-    ports             => '8004',
-    options           => 'check inter 2000 rise 2 fall 5',
+  ::profile::services::haproxy::backend { 'HeatAdmin':
+    backend   => 'bk_heat_api_admin',
+    port      => 8004,
+    interface => $if,
+    options   => 'check inter 2000 rise 2 fall 5',
   }
 
-  profile::services::haproxy::tools::register { "HeatApiAdmin-${::hostname}":
-    servername  => $::hostname,
-    backendname => 'bk_heat_api_admin',
+  ::profile::services::haproxy::backend { 'HeatCfnPublic':
+    backend   => 'bk_heat_cfn_public',
+    port      => 8000,
+    interface => $if,
+    options   => 'check inter 2000 rise 2 fall 5',
   }
 
-  @@haproxy::balancermember { "heat-admin-${::fqdn}":
-    listening_service => 'bk_heat_api_admin',
-    server_names      => $::hostname,
-    ipaddresses       => $ip,
-    ports             => '8004',
-    options           => 'check inter 2000 rise 2 fall 5',
-  }
-
-  profile::services::haproxy::tools::register { "HeatCfnPublic-${::hostname}":
-    servername  => $::hostname,
-    backendname => 'bk_heat_cfn_public',
-  }
-
-  @@haproxy::balancermember { "heat-cfn-public-${::fqdn}":
-    listening_service => 'bk_heat_cfn_public',
-    server_names      => $::hostname,
-    ipaddresses       => $ip,
-    ports             => '8000',
-    options           => 'check inter 2000 rise 2 fall 5',
-  }
-
-  profile::services::haproxy::tools::register { "HeatCfnAdmin-${::hostname}":
-    servername  => $::hostname,
-    backendname => 'bk_heat_cfn_admin',
-  }
-
-  @@haproxy::balancermember { "heat-cfn-admin-${::fqdn}":
-    listening_service => 'bk_heat_cfn_admin',
-    server_names      => $::hostname,
-    ipaddresses       => $ip,
-    ports             => '8000',
-    options           => 'check inter 2000 rise 2 fall 5',
+  ::profile::services::haproxy::backend { 'HeatCfnAdmin':
+    backend   => 'bk_heat_cfn_admin',
+    port      => 8000,
+    interface => $if,
+    options   => 'check inter 2000 rise 2 fall 5',
   }
 }

--- a/manifests/keystone/haproxy/backend.pp
+++ b/manifests/keystone/haproxy/backend.pp
@@ -1,31 +1,18 @@
 # Configures the haproxy backends for keystone
 class ntnuopenstack::keystone::haproxy::backend {
   $if = lookup('profile::interfaces::management')
-  $ip = $::facts['networking']['interfaces'][$if]['ip']
 
-  profile::services::haproxy::tools::register { "KeystonePublic-${::hostname}":
-    servername  => $::hostname,
-    backendname => 'bk_keystone_public',
+  ::profile::services::haproxy::backend { 'KeystonePublic':
+    backend   => 'bk_keystone_public',
+    port      => 5000,
+    interface => $if,
+    options   => 'check inter 2000 rise 2 fall 5',
   }
 
-  @@haproxy::balancermember { "keystone-public-${::fqdn}":
-    listening_service => 'bk_keystone_public',
-    server_names      => $::hostname,
-    ipaddresses       => $ip,
-    ports             => '5000',
-    options           => 'check inter 2000 rise 2 fall 5',
-  }
-
-  profile::services::haproxy::tools::register { "KeystoneInternal-${::hostname}":
-    servername  => $::hostname,
-    backendname => 'bk_keystone_internal',
-  }
-
-  @@haproxy::balancermember { "keystone-internal-${::fqdn}":
-    listening_service => 'bk_keystone_internal',
-    server_names      => $::hostname,
-    ipaddresses       => $ip,
-    ports             => '5000',
-    options           => 'check inter 2000 rise 2 fall 5',
+  ::profile::services::haproxy::backend { 'KeystoneInternal':
+    backend   => 'bk_keystone_internal',
+    port      => 5000,
+    interface => $if,
+    options   => 'check inter 2000 rise 2 fall 5',
   }
 }

--- a/manifests/magnum/haproxy/backend.pp
+++ b/manifests/magnum/haproxy/backend.pp
@@ -1,31 +1,18 @@
 # Configures the haproxy backends for magnum
 class ntnuopenstack::magnum::haproxy::backend {
   $if = lookup('profile::interfaces::management')
-  $ip = $::facts['networking']['interfaces'][$if]['ip']
 
-  profile::services::haproxy::tools::register { "MagnumPublic-${::hostname}":
-    servername  => $::hostname,
-    backendname => 'bk_magnum_public',
+  ::profile::services::haproxy::backend { 'MagnumPublic':
+    backend   => 'bk_magnum_public',
+    port      => 9511,
+    interface => $if,
+    options   => 'check inter 2000 rise 2 fall 5',
   }
 
-  @@haproxy::balancermember { "magnum-public-${::fqdn}":
-    listening_service => 'bk_magnum_public',
-    server_names      => $::hostname,
-    ipaddresses       => $ip,
-    ports             => '9511',
-    options           => 'check inter 2000 rise 2 fall 5',
-  }
-
-  profile::services::haproxy::tools::register { "MagnumAdmin-${::hostname}":
-    servername  => $::hostname,
-    backendname => 'bk_magnum_admin',
-  }
-
-  @@haproxy::balancermember { "magnum-admin-${::fqdn}":
-    listening_service => 'bk_magnum_admin',
-    server_names      => $::hostname,
-    ipaddresses       => $ip,
-    ports             => '9511',
-    options           => 'check inter 2000 rise 2 fall 5',
+  ::profile::services::haproxy::backend { 'MagnumAdmin':
+    backend   => 'bk_magnum_admin',
+    port      => 9511,
+    interface => $if,
+    options   => 'check inter 2000 rise 2 fall 5',
   }
 }

--- a/manifests/neutron/haproxy/backend.pp
+++ b/manifests/neutron/haproxy/backend.pp
@@ -1,29 +1,18 @@
 # Configures the haproxy backends for neutron
 class ntnuopenstack::neutron::haproxy::backend {
   $if = lookup('profile::interfaces::management')
-  $ip = $::facts['networking']['interfaces'][$if]['ip']
 
-  profile::services::haproxy::tools::register { "NeutronPublic-${::hostname}":
-    servername  => $::hostname,
-    backendname => 'bk_neutron_public',
-  }
-  @@haproxy::balancermember { "neutron-public-${::fqdn}":
-    listening_service => 'bk_neutron_public',
-    server_names      => $::hostname,
-    ipaddresses       => $ip,
-    ports             => '9696',
-    options           => 'check inter 2000 rise 2 fall 5',
+  ::profile::services::haproxy::backend { 'NeutronPublic':
+    backend   => 'bk_neutron_public',
+    port      => 9696,
+    interface => $if,
+    options   => 'check inter 2000 rise 2 fall 5',
   }
 
-  profile::services::haproxy::tools::register { "NeutronAdmin-${::hostname}":
-    servername  => $::hostname,
-    backendname => 'bk_neutron_api_admin',
-  }
-  @@haproxy::balancermember { "neutron-admin-${::fqdn}":
-    listening_service => 'bk_neutron_api_admin',
-    server_names      => $::hostname,
-    ipaddresses       => $ip,
-    ports             => '9696',
-    options           => 'check inter 2000 rise 2 fall 5',
+  ::profile::services::haproxy::backend { 'NeutronAdmin':
+    backend   => 'bk_neutron_api_admin',
+    port      => 9696,
+    interface => $if,
+    options   => 'check inter 2000 rise 2 fall 5',
   }
 }

--- a/manifests/nova/haproxy/backend/api.pp
+++ b/manifests/nova/haproxy/backend/api.pp
@@ -1,31 +1,18 @@
 # Exports a server-definition to be collected by the haproxy backends.
 class ntnuopenstack::nova::haproxy::backend::api {
   $if = lookup('profile::interfaces::management')
-  $ip = $::facts['networking']['interfaces'][$if]['ip']
 
-  profile::services::haproxy::tools::register { "NovaPublic-${::hostname}":
-    servername  => $::hostname,
-    backendname => 'bk_nova_public',
+  ::profile::services::haproxy::backend { 'NovaPublic':
+    backend   => 'bk_nova_public',
+    port      => 8774,
+    interface => $if,
+    options   => 'check inter 2000 rise 2 fall 5',
   }
 
-  @@haproxy::balancermember { "nova-public-${::fqdn}":
-    listening_service => 'bk_nova_public',
-    server_names      => $::hostname,
-    ipaddresses       => $ip,
-    ports             => '8774',
-    options           => 'check inter 2000 rise 2 fall 5',
-  }
-
-  profile::services::haproxy::tools::register { "NovaAdmin-${::hostname}":
-    servername  => $::hostname,
-    backendname => 'bk_nova_api_admin',
-  }
-
-  @@haproxy::balancermember { "nova-admin-${::fqdn}":
-    listening_service => 'bk_nova_api_admin',
-    server_names      => $::hostname,
-    ipaddresses       => $ip,
-    ports             => '8774',
-    options           => 'check inter 2000 rise 2 fall 5',
+  ::profile::services::haproxy::backend { 'NovaAdmin':
+    backend   => 'bk_nova_api_admin',
+    port      => 8774,
+    interface => $if,
+    options   => 'check inter 2000 rise 2 fall 5',
   }
 }

--- a/manifests/nova/haproxy/backend/metadata.pp
+++ b/manifests/nova/haproxy/backend/metadata.pp
@@ -1,18 +1,11 @@
 # Exports a server-definition to be collected by the haproxy backends.
 class ntnuopenstack::nova::haproxy::backend::metadata {
   $if = lookup('profile::interfaces::management')
-  $ip = $::facts['networking']['interfaces'][$if]['ip']
 
-  profile::services::haproxy::tools::register { "NovaMetadata-${::hostname}":
-    servername  => $::hostname,
-    backendname => 'bk_nova_metadata',
-  }
-
-  @@haproxy::balancermember { "nova-metadata-${::fqdn}":
-    listening_service => 'bk_nova_metadata',
-    server_names      => $::hostname,
-    ipaddresses       => $ip,
-    ports             => '8775',
-    options           => 'check inter 2000 rise 2 fall 5',
+  ::profile::services::haproxy::backend { 'NovaMetadata':
+    backend   => 'bk_nova_metadata',
+    port      => 8775,
+    interface => $if,
+    options   => 'check inter 2000 rise 2 fall 5',
   }
 }

--- a/manifests/nova/haproxy/backend/vnc.pp
+++ b/manifests/nova/haproxy/backend/vnc.pp
@@ -1,18 +1,11 @@
 # Exports a server-definition to be collected by the haproxy backends.
 class ntnuopenstack::nova::haproxy::backend::vnc {
   $if = lookup('profile::interfaces::management')
-  $ip = $::facts['networking']['interfaces'][$if]['ip']
 
-  profile::services::haproxy::tools::register { "NovaVNC-${::hostname}":
-    servername  => $::hostname,
-    backendname => 'bk_nova_vnc',
-  }
-
-  @@haproxy::balancermember { "nova-vnc-${::fqdn}":
-    listening_service => 'bk_nova_vnc',
-    server_names      => $::hostname,
-    ipaddresses       => $ip,
-    ports             => '6080',
-    options           => 'check inter 2000 rise 2 fall 5',
+  ::profile::services::haproxy::backend { 'NovaVNC':
+    backend   => 'bk_nova_vnc',
+    port      => 6080,
+    interface => $if,
+    options   => 'check inter 2000 rise 2 fall 5',
   }
 }

--- a/manifests/octavia/haproxy/backend.pp
+++ b/manifests/octavia/haproxy/backend.pp
@@ -2,31 +2,18 @@
 class ntnuopenstack::octavia::haproxy::backend {
   $if = lookup('profile::interfaces::management')
   $port = lookup('ntnuopenstack::octavia::api::port', Stdlib::Port)
-  $ip = $::facts['networking']['interfaces'][$if]['ip']
 
-  profile::services::haproxy::tools::register { "OctaviaPublic-${::hostname}":
-    servername  => $::hostname,
-    backendname => 'bk_octavia_public',
+  ::profile::services::haproxy::backend { 'OctaviaPublic':
+    backend   => 'bk_octavia_public',
+    port      => $port,
+    interface => $if,
+    options   => 'check inter 2000 rise 2 fall 5',
   }
 
-  @@haproxy::balancermember { "octavia-public-${::fqdn}":
-    listening_service => 'bk_octavia_public',
-    server_names      => $::hostname,
-    ipaddresses       => $ip,
-    ports             => $port,
-    options           => 'check inter 2000 rise 2 fall 5',
-  }
-
-  profile::services::haproxy::tools::register { "OctaviaAdmin-${::hostname}":
-    servername  => $::hostname,
-    backendname => 'bk_octavia_admin',
-  }
-
-  @@haproxy::balancermember { "octavia-admin-${::fqdn}":
-    listening_service => 'bk_octavia_admin',
-    server_names      => $::hostname,
-    ipaddresses       => $ip,
-    ports             => $port,
-    options           => 'check inter 2000 rise 2 fall 5',
+  ::profile::services::haproxy::backend { 'OctaviaAdmin':
+    backend   => 'bk_octavia_admin',
+    port      => $port,
+    interface => $if,
+    options   => 'check inter 2000 rise 2 fall 5',
   }
 }

--- a/manifests/placement/haproxy/backend.pp
+++ b/manifests/placement/haproxy/backend.pp
@@ -1,31 +1,18 @@
 # Exports a server-definition to be collected by the haproxy backends.
 class ntnuopenstack::placement::haproxy::backend {
   $if = lookup('profile::interfaces::management')
-  $ip = $::facts['networking']['interfaces'][$if]['ip']
 
-  profile::services::haproxy::tools::register { "PlacementAdmin-${::hostname}":
-    servername  => $::hostname,
-    backendname => 'bk_placement_admin',
+  ::profile::services::haproxy::backend { 'PlacementPublic':
+    backend   => 'bk_placement_public',
+    port      => 8778,
+    interface => $if,
+    options   => 'check inter 2000 rise 2 fall 5',
   }
 
-  @@haproxy::balancermember { "placement-admin-${::fqdn}":
-    listening_service => 'bk_placement_admin',
-    server_names      => $::hostname,
-    ipaddresses       => $ip,
-    ports             => '8778',
-    options           => 'check inter 2000 rise 2 fall 5',
-  }
-
-  profile::services::haproxy::tools::register { "PlacementPublic-${::hostname}":
-    servername  => $::hostname,
-    backendname => 'bk_placement_public',
-  }
-
-  @@haproxy::balancermember { "placement-public-${::fqdn}":
-    listening_service => 'bk_placement_public',
-    server_names      => $::hostname,
-    ipaddresses       => $ip,
-    ports             => '8778',
-    options           => 'check inter 2000 rise 2 fall 5',
+  ::profile::services::haproxy::backend { 'PlacementAdmin':
+    backend   => 'bk_placement_admin',
+    port      => 8778,
+    interface => $if,
+    options   => 'check inter 2000 rise 2 fall 5',
   }
 }

--- a/manifests/swift/haproxy/backend.pp
+++ b/manifests/swift/haproxy/backend.pp
@@ -1,31 +1,18 @@
 # Configures the haproxy backends for swift
 class ntnuopenstack::swift::haproxy::backend {
   $if = lookup('profile::interfaces::management')
-  $ip = $::facts['networking']['interfaces'][$if]['ip']
 
-  profile::services::haproxy::tools::register { "SwiftPublic-${::hostname}":
-    servername  => $::hostname,
-    backendname => 'bk_swift_public',
+  ::profile::services::haproxy::backend { 'SwiftPublic':
+    backend   => 'bk_swift_public',
+    port      => 7480,
+    interface => $if,
+    options   => 'check inter 2000 rise 2 fall 5',
   }
 
-  @@haproxy::balancermember { "swift-public-${::fqdn}":
-    listening_service => 'bk_swift_public',
-    server_names      => $::hostname,
-    ipaddresses       => $ip,
-    ports             => '7480',
-    options           => 'check inter 2000 rise 2 fall 5',
-  }
-
-  profile::services::haproxy::tools::register { "SwiftAdmin-${::hostname}":
-    servername  => $::hostname,
-    backendname => 'bk_swift_admin',
-  }
-
-  @@haproxy::balancermember { "swift-admin-${::fqdn}":
-    listening_service => 'bk_swift_admin',
-    server_names      => $::hostname,
-    ipaddresses       => $ip,
-    ports             => '7480',
-    options           => 'check inter 2000 rise 2 fall 5',
+  ::profile::services::haproxy::backend { 'SwiftAdmin':
+    backend   => 'bk_swift_admin',
+    port      => 7480,
+    interface => $if,
+    options   => 'check inter 2000 rise 2 fall 5',
   }
 }


### PR DESCRIPTION
This release refactors how we define haproxy backends, and starts to use the define created in v1.18.0. The change is a no-op, and safe to roll out. The following classes is refactored:

- ntnuopenstack::barbican::haproxy::backend
- ntnuopenstack::cinder::haproxy::backend
- ntnuopenstack::glance::haproxy::backend
- ntnuopenstack::heat::haproxy::backend
- ntnuopenstack::keystone::haproxy::backend
- ntnuopenstack::magnum::haproxy::backend
- ntnuopenstack::neutron::haproxy::backend
- ntnuopenstack::nova::haproxy::backend::api
- ntnuopenstack::nova::haproxy::backend::metadata
- ntnuopenstack::nova::haproxy::backend::vnc
- ntnuopenstack::octavia::haproxy::backend
- ntnuopenstack::placement::haproxy::backend
- ntnuopenstack::swift::haproxy::backend