### PR TITLE
Victoria

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -40,6 +40,7 @@ ntnuopenstack::neutron::fwaas::enabled: true
 ntnuopenstack::neutron::metadata::ip: "%{alias('ntnuopenstack::endpoint::admin::ipv4')}"
 ntnuopenstack::neutron::mysql::ip: "%{alias('ntnuopenstack::endpoint::admin::ipv4')}"
 
+ntnuopenstack::nova::cpu::base_model: "%{alias('ntnuopenstack::nova::libvirt_model')}"
 ntnuopenstack::nova::db::sync: "%{alias('ntnuopenstack::db::sync')}"
 ntnuopenstack::nova::endpoint::admin: "%{alias('ntnuopenstack::endpoint::admin')}"
 ntnuopenstack::nova::endpoint::internal: "%{alias('ntnuopenstack::endpoint::internal')}"

--- a/manifests/glance/api.pp
+++ b/manifests/glance/api.pp
@@ -30,6 +30,12 @@ class ntnuopenstack::glance::api {
     'default_value' => true,
   })
 
+  $disk_formats = lookup('ntnuopenstack::glance::disk_formats', {
+    'value_type'    => Hash[String, String],
+    'default_value' => {'raw' => '', 'qcow2' => ''}
+  })
+  $disk_formats_real = join(keys($disk_formats), ',')
+
   require ::ntnuopenstack::repo
   contain ::ntnuopenstack::glance::ceph
   contain ::ntnuopenstack::glance::firewall::server::api
@@ -51,6 +57,7 @@ class ntnuopenstack::glance::api {
     auth_strategy                => '',
     database_connection          => $database_connection,
     default_backend              => 'ceph-default',
+    disk_formats                 => $disk_formats_real,
     enabled_backends             => ['ceph-default:rbd'],
     enable_proxy_headers_parsing => $confhaproxy,
     show_image_direct_url        => true,

--- a/manifests/glance/ceph.pp
+++ b/manifests/glance/ceph.pp
@@ -4,10 +4,6 @@ class ntnuopenstack::glance::ceph {
 
   require ::profile::ceph::client
 
-  exec { '/usr/bin/ceph osd pool create images 32' :
-    unless  => '/usr/bin/ceph osd pool get images size',
-  }
-
   ceph_config {
       'client.glance/key': value => $glance_key;
   }

--- a/manifests/glance/formats.pp
+++ b/manifests/glance/formats.pp
@@ -1,19 +1,13 @@
 # Defines which formats we allow in our glance API.
 class ntnuopenstack::glance::formats {
-  $disk_formats = lookup('ntnuopenstack::glance::disk_formats', {
-    'value_type'    => Hash[String, String],
-    'default_value' => {'raw' => '', 'qcow2' => ''}
-  })
   $container_formats = lookup('ntnuopenstack::glance::container_formats', {
     'value_type'    => Array[String],
     'default_value' => ['bare'],
   })
 
-  $disk_formats_real = join(keys($disk_formats), ',')
   $container_formats_real = join($container_formats, ',')
 
   glance_api_config {
     'image_format/container_formats': value => $container_formats_real;
-    'image_format/disk_formats':      value => $disk_formats_real;
   }
 }

--- a/manifests/heat/deps.pp
+++ b/manifests/heat/deps.pp
@@ -1,0 +1,6 @@
+# Install some client-libraries suddenly required for the heat-engine to start.
+class ntnuopenstack::heat::deps {
+  package { [ 'python3-vitrageclient', 'python3-etcd3gw', 'python3-zunclient' ]:
+    ensure => 'present',
+  }
+}

--- a/manifests/heat/engine.pp
+++ b/manifests/heat/engine.pp
@@ -6,6 +6,7 @@ class ntnuopenstack::heat::engine {
 
   require ::ntnuopenstack::repo
   require ::ntnuopenstack::heat::base
+  include ::ntnuopenstack::heat::deps
 
   class { '::heat::engine':
     auth_encryption_key           => $auth_encryption_key,

--- a/manifests/neutron/agents.pp
+++ b/manifests/neutron/agents.pp
@@ -16,9 +16,6 @@ class ntnuopenstack::neutron::agents {
   require ::ntnuopenstack::neutron::firewall::l3agent
   require ::ntnuopenstack::repo
 
-  # TODO: We should deprecate the use of neutronnet-nodes as bgp-dragents. 
-  include ::ntnuopenstack::neutron::bgp
-
   class { '::neutron::agents::metadata':
     shared_secret => $metadata_secret,
     metadata_host => $metadata_ip,

--- a/manifests/neutron/api.pp
+++ b/manifests/neutron/api.pp
@@ -1,11 +1,5 @@
 # Installs and configures the neutron api
 class ntnuopenstack::neutron::api {
-  # Determine where the database is
-  $mysql_password = lookup('ntnuopenstack::neutron::mysql::password', String)
-  $mysql_ip = lookup('ntnuopenstack::neutron::mysql::ip', Stdlib::IP::Address)
-  $database_connection = "mysql+pymysql://neutron:${mysql_password}@${mysql_ip}/neutron"
-  $sync_db = lookup('ntnuopenstack::neutron::db::sync', Boolean)
-
   # Create a list of memceche-servers.
   $cache_servers = lookup('profile::memcache::servers', {
     'value_type' => Array[Stdlib::IP::Address],
@@ -21,6 +15,7 @@ class ntnuopenstack::neutron::api {
 
   # Openstack parameters
   $region = lookup('ntnuopenstack::region', String)
+  $sync_db = lookup('ntnuopenstack::neutron::db::sync', Boolean)
   $nova_password = lookup('ntnuopenstack::nova::keystone::password', String)
   $neutron_password = lookup('ntnuopenstack::neutron::keystone::password', String)
   $fwaas_enable = lookup('ntnuopenstack::neutron::fwaas::enabled', Boolean)
@@ -42,6 +37,7 @@ class ntnuopenstack::neutron::api {
   })
 
   require ::ntnuopenstack::neutron::base
+  require ::ntnuopenstack::neutron::dbconnection
   include ::ntnuopenstack::neutron::firewall::api
   include ::ntnuopenstack::neutron::ml2::config
   include ::profile::monitoring::munin::plugin::openstack::neutronapi
@@ -61,18 +57,17 @@ class ntnuopenstack::neutron::api {
 
   # Install the neutron api
   class { '::neutron::server':
-    database_connection              => $database_connection,
-    sync_db                          => $sync_db,
     allow_automatic_l3agent_failover => true,
     allow_automatic_dhcp_failover    => true,
-    service_providers                => $service_providers,
     enable_proxy_headers_parsing     => $confhaproxy,
+    service_providers                => $service_providers,
+    sync_db                          => $sync_db,
   }
 
   # Configure nova notifications system
   class { '::neutron::server::notifications':
-    password    => $nova_password,
     auth_url    => "${keystone_admin}:5000",
+    password    => $nova_password,
     region_name => $region,
   }
 }

--- a/manifests/neutron/api.pp
+++ b/manifests/neutron/api.pp
@@ -31,6 +31,10 @@ class ntnuopenstack::neutron::api {
     'value_type'    => Array[String],
     'default_value' => $sp,
   })
+  $register_loadbalancer = lookup('profile::haproxy::register', {
+    'value_type'    => Boolean,
+    'default_value' => true,
+  })
 
   require ::ntnuopenstack::neutron::base
   require ::ntnuopenstack::neutron::dbconnection
@@ -52,7 +56,7 @@ class ntnuopenstack::neutron::api {
   class { '::neutron::server':
     allow_automatic_l3agent_failover => true,
     allow_automatic_dhcp_failover    => true,
-    enable_proxy_headers_parsing     => $confhaproxy,
+    enable_proxy_headers_parsing     => $register_loadbalancer,
     service_providers                => $service_providers,
     sync_db                          => $sync_db,
   }

--- a/manifests/neutron/api.pp
+++ b/manifests/neutron/api.pp
@@ -31,20 +31,13 @@ class ntnuopenstack::neutron::api {
     'value_type'    => Array[String],
     'default_value' => $sp,
   })
-  $confhaproxy = lookup('ntnuopenstack::haproxy::configure::backend', {
-    'value_type'    => Boolean,
-    'default_value' => true,
-  })
 
   require ::ntnuopenstack::neutron::base
   require ::ntnuopenstack::neutron::dbconnection
   include ::ntnuopenstack::neutron::firewall::api
+  include ::ntnuopenstack::neutron::haproxy::backend
   include ::ntnuopenstack::neutron::ml2::config
   include ::profile::monitoring::munin::plugin::openstack::neutronapi
-
-  if($confhaproxy) {
-    contain ::ntnuopenstack::neutron::haproxy::backend
-  }
 
   # Configure how neutron communicates with keystone
   class { '::neutron::keystone::authtoken':

--- a/manifests/neutron/dbconnection.pp
+++ b/manifests/neutron/dbconnection.pp
@@ -1,0 +1,10 @@
+# Configures neutrons database connection 
+class ntnuopenstack::neutron::dbconnection {
+  $mysql_password = lookup('ntnuopenstack::neutron::mysql::password', String)
+  $mysql_ip = lookup('ntnuopenstack::neutron::mysql::ip', Stdlib::IP::Address)
+  $conn = "mysql+pymysql://neutron:${mysql_password}@${mysql_ip}/neutron"
+
+  class { '::neutron::db':
+    database_connection => $conn,
+  }
+}

--- a/manifests/neutron/ml2/config.pp
+++ b/manifests/neutron/ml2/config.pp
@@ -6,21 +6,33 @@ class ntnuopenstack::neutron::ml2::config {
     'value_type' => Enum['vlan', 'vxlan'],
   })
 
+  $connections = lookup('ntnuopenstack::neutron::external::connections', {
+    'value_type'    => Hash[String, Variant[String, Hash]],
+    'default_value' => {},
+  })
+
+  $physnetmtu = $connections.map | $key, $value | {
+    $mtu = pick($value['mtu'], 1500)
+    "${key}:${mtu}"
+  }
+
   if($strategy == 'vlan') {
     class { '::neutron::plugins::ml2':
-      extension_drivers    => ['port_security'],
-      type_drivers         => ['vlan', 'flat'],
-      tenant_network_types => ['vlan'],
-      mechanism_drivers    => ['openvswitch', 'l2population'],
-      network_vlan_ranges  => ["physnet-vlan:${low}:${high}"],
+      extension_drivers     => ['port_security'],
+      mechanism_drivers     => ['openvswitch', 'l2population'],
+      network_vlan_ranges   => ["physnet-vlan:${low}:${high}"],
+      physical_network_mtus => $physnetmtu,
+      tenant_network_types  => ['vlan'],
+      type_drivers          => ['vlan', 'flat'],
     }
   } elsif($strategy == 'vxlan') {
     class { '::neutron::plugins::ml2':
-      extension_drivers    => ['port_security'],
-      type_drivers         => ['vxlan', 'flat'],
-      tenant_network_types => ['vxlan'],
-      mechanism_drivers    => ['openvswitch', 'l2population'],
-      vni_ranges           => "${low}:${high}"
+      extension_drivers     => ['port_security'],
+      mechanism_drivers     => ['openvswitch', 'l2population'],
+      physical_network_mtus => $physnetmtu,
+      tenant_network_types  => ['vxlan'],
+      type_drivers          => ['vxlan', 'flat'],
+      vni_ranges            => "${low}:${high}"
     }
   }
 }

--- a/manifests/nova/base/compute.pp
+++ b/manifests/nova/base/compute.pp
@@ -30,6 +30,7 @@ class ntnuopenstack::nova::base::compute {
   }
 
   class { '::nova':
+    api_database_connection       => absent,
     database_connection           => $database_connection,
     default_transport_url         => $transport_url,
     block_device_allocate_retries => 120,

--- a/manifests/nova/base/compute.pp
+++ b/manifests/nova/base/compute.pp
@@ -41,4 +41,8 @@ class ntnuopenstack::nova::base::compute {
     auth_url    => "${internal_endpoint}:5000/v3",
     region_name => $region,
   }
+
+  nova_config {
+    'api_database/connection': ensure => absent;
+  }
 }

--- a/manifests/nova/base/compute.pp
+++ b/manifests/nova/base/compute.pp
@@ -30,7 +30,6 @@ class ntnuopenstack::nova::base::compute {
   }
 
   class { '::nova':
-    api_database_connection       => absent,
     database_connection           => $database_connection,
     default_transport_url         => $transport_url,
     block_device_allocate_retries => 120,

--- a/manifests/nova/libvirt.pp
+++ b/manifests/nova/libvirt.pp
@@ -35,8 +35,9 @@ class ntnuopenstack::nova::libvirt {
 
   if($cpu_model) {
     $cpuconfig = {
-      cpu_mode   => 'custom',
-      cpu_models => [ $cpu_model ] + $cpu_models,
+      cpu_mode          => 'custom',
+      cpu_models        => [ $cpu_model ] + $cpu_models,
+      migration_support => true,
     }
   } else {
     $cpuconfig = {
@@ -47,7 +48,6 @@ class ntnuopenstack::nova::libvirt {
   class { '::nova::compute::libvirt':
     cpu_model_extra_flags => $cpu_model_extra_flags,
     disk_cachemodes       => [ 'network=writeback' ],
-    migration_support     => true,
     vncserver_listen      => $management_ip,
     *                     => $cpuconfig,
   }

--- a/manifests/nova/libvirt.pp
+++ b/manifests/nova/libvirt.pp
@@ -1,10 +1,5 @@
 # This class installs and configures libvirt for nova's use.
 class ntnuopenstack::nova::libvirt {
-  $nova_libvirt_type = lookup('ntnuopenstack::nova::libvirt_type', {
-    'default_value' => 'kvm',
-    'value_type'    => Enum['kvm', 'qemu'],
-  })
-
   # We can instruct libvirt to expose a certain CPU-model to our VM's. This is
   # useful to allow live-migration between hosts. If a model is specified A
   # 'least-common-denominator' CPU model, supported by all compute-nodes where
@@ -45,7 +40,7 @@ class ntnuopenstack::nova::libvirt {
     }
   } else {
     $cpuconfig = {
-      cpu_mode => false,
+      cpu_mode => 'host-passthrough',
     }
   }
 
@@ -53,7 +48,6 @@ class ntnuopenstack::nova::libvirt {
     cpu_model_extra_flags => $cpu_model_extra_flags,
     disk_cachemodes       => [ 'network=writeback' ],
     migration_support     => true,
-    virt_type             => $nova_libvirt_type,
     vncserver_listen      => $management_ip,
     *                     => $cpuconfig,
   }

--- a/manifests/nova/services.pp
+++ b/manifests/nova/services.pp
@@ -25,9 +25,7 @@ class ntnuopenstack::nova::services {
     'value_type'    => Integer,
   })
 
-  class { '::nova::conductor':
-    enabled => true,
-  }
+  include ::nova::conductor
 
   class { '::nova::scheduler':
     discover_hosts_in_cells_interval => $discover_interval,

--- a/manifests/nova/services.pp
+++ b/manifests/nova/services.pp
@@ -34,11 +34,7 @@ class ntnuopenstack::nova::services {
   }
 
   class { '::nova::scheduler::filter':
-    scheduler_default_filters => $default_filters_real,
-  }
-
-  nova_config {
-    'filter_scheduler/build_failure_weight_multiplier':
-      value => 0;
+    scheduler_default_filters       => $default_filters_real,
+    build_failure_weight_multiplier => 0,
   }
 }

--- a/manifests/nova/vncproxy.pp
+++ b/manifests/nova/vncproxy.pp
@@ -40,10 +40,7 @@ class ntnuopenstack::nova::vncproxy {
   }
 
   nova::generic_service { 'vncproxy':
-    enabled        => true,
-    manage_service => true,
     package_name   => 'nova-novncproxy',
     service_name   => 'nova-novncproxy',
-    ensure_package => present,
   }
 }

--- a/manifests/nova/vncproxy.pp
+++ b/manifests/nova/vncproxy.pp
@@ -4,6 +4,10 @@ class ntnuopenstack::nova::vncproxy {
   include ::ntnuopenstack::nova::firewall::vncproxy
   require ::ntnuopenstack::repo
 
+  $enabled = lookup('ntnuopenstack::enabled', {
+    'default_value' => true,
+    'value_type'    => Boolean,
+  })
   $host = lookup('ntnuopenstack::nova::vncproxy::host')
   $port = lookup('ntnuopenstack::nova::vncproxy::port', {
     'default_value' => 6080,
@@ -40,7 +44,8 @@ class ntnuopenstack::nova::vncproxy {
   }
 
   nova::generic_service { 'vncproxy':
-    package_name   => 'nova-novncproxy',
-    service_name   => 'nova-novncproxy',
+    enabled      => $enabled,
+    package_name => 'nova-novncproxy',
+    service_name => 'nova-novncproxy',
   }
 }

--- a/manifests/octavia/api.pp
+++ b/manifests/octavia/api.pp
@@ -3,14 +3,20 @@ class ntnuopenstack::octavia::api {
   $api_port = lookup('ntnuopenstack::octavia::api::port', Stdlib::Port)
   $dbsync = lookup('ntnuopenstack::octavia::db::sync', Boolean, 'first', false)
 
+  $register_loadbalancer = lookup('profile::haproxy::register', {
+    'default_value' => true,
+    'value_type'    => Boolean,
+  })
+
   include ::ntnuopenstack::octavia::base
   include ::ntnuopenstack::octavia::firewall::api
   include ::ntnuopenstack::octavia::haproxy::backend
   require ::ntnuopenstack::repo
 
   class { '::octavia::api':
-    port           => $api_port,
-    sync_db        => $dbsync,
-    api_v1_enabled => false,
+    api_v1_enabled               => false,
+    enable_proxy_headers_parsing => $register_loadbalancer,
+    port                         => $api_port,
+    sync_db                      => $dbsync,
   }
 }

--- a/manifests/placement/api.pp
+++ b/manifests/placement/api.pp
@@ -1,11 +1,5 @@
-# Creates the databases for the placement service.
+# Installs and configures Placement API
 class ntnuopenstack::placement::api {
-  # Determine database-settings
-  $mysql_pass = lookup('ntnuopenstack::placement::mysql::password', String)
-  $mysql_ip = lookup('ntnuopenstack::placement::mysql::ip', Stdlib::IP::Address)
-  $database_connection = "mysql+pymysql://placement:${mysql_pass}@${mysql_ip}/placement"
-  $db_sync = lookup('ntnuopenstack::placement::db::sync', Boolean)
-
   # Retrieve openstack-settings
   $region = lookup('ntnuopenstack::region', String)
   $keystone_password = lookup('ntnuopenstack::placement::keystone::password',
@@ -14,6 +8,7 @@ class ntnuopenstack::placement::api {
                                 Stdlib::Httpurl)
   $keystone_public = lookup('ntnuopenstack::keystone::endpoint::public',
                                 Stdlib::Httpurl)
+  $db_sync = lookup('ntnuopenstack::placement::db::sync', Boolean)
 
   # Retrieve addresses for the memcached servers
   $cache_servers = lookup('profile::memcache::servers', {
@@ -31,6 +26,7 @@ class ntnuopenstack::placement::api {
   })
 
   require ::ntnuopenstack::repo
+  include ::ntnuopenstack::placement::dbconnection
   include ::ntnuopenstack::placement::firewall::server
 
   if($confhaproxy) {
@@ -44,8 +40,9 @@ class ntnuopenstack::placement::api {
     sync_db => $db_sync,
   }
 
-  class { '::placement::db':
-    database_connection => $database_connection,
+  class { '::placement::api':
+    service_name => 'httpd',
+    sync_db      => $db_sync,
   }
 
   class { '::placement::keystone::authtoken':

--- a/manifests/placement/api.pp
+++ b/manifests/placement/api.pp
@@ -41,8 +41,8 @@ class ntnuopenstack::placement::api {
   }
 
   class { '::placement::api':
-    service_name => 'httpd',
-    sync_db      => $db_sync,
+    api_service_name => 'httpd',
+    sync_db          => $db_sync,
   }
 
   class { '::placement::keystone::authtoken':

--- a/manifests/placement/dbconnection.pp
+++ b/manifests/placement/dbconnection.pp
@@ -1,0 +1,11 @@
+# Configures placement to use its database
+class ntnuopenstack::placement::dbconnection {
+  # Determine database-settings
+  $mysql_pass = lookup('ntnuopenstack::placement::mysql::password', String)
+  $mysql_ip = lookup('ntnuopenstack::placement::mysql::ip', Stdlib::IP::Address)
+  $database_connection = "mysql+pymysql://placement:${mysql_pass}@${mysql_ip}/placement"
+
+  class { '::placement::db':
+    database_connection => $database_connection,
+  }
+}

--- a/manifests/placement/endpoint.pp
+++ b/manifests/placement/endpoint.pp
@@ -1,4 +1,4 @@
-# Installs and configures Placement API
+# Configures the placement API endpoint in keystone 
 class ntnuopenstack::placement::endpoint {
   # Openstack settings
   $region = lookup('ntnuopenstack::region', String)


### PR DESCRIPTION
New features:
 - Victoria
 - Allow specifying tenant-network's MTU

Deprecations:
 - Neutronnet-nodes cannot be bgp-agents anymore.

New hiera-keys:
 - `ntnuopenstack::enabled` - A new generic key stating if openstack-services should run or not. Some work remains before this is used everywhere.
 - `ntnuopenstack::nova::cpu::base_model` - Determines the minimum common cpu-IA all your compute-nodes supports. Same value as the key `ntnuopenstack::nova::libvirt_model` previously had.
 - `ntnuopenstack::nova::cpu::extra_models` - A list of cpu-IA's which is supported in addition to the base one. Allows us to have flavors giving access to more modern instructions even though not all our compute-nodes supports it.
 - `ntnuopenstack::neutron::external::connections`: The config-hash for external networks now can contain a value with the "mtu" key, to set the MTU for that particular external connection.

Removed hiera-keys:
 - `ntnuopenstack::nova::libvirt_model`