### PR TITLE
Diskedcompute

### DIFF
--- a/manifests/nova/compute/disk.pp
+++ b/manifests/nova/compute/disk.pp
@@ -8,7 +8,7 @@ class ntnuopenstack::nova::compute::disk {
   $type = lookup('ntnuopenstack::compute::disk::type', {
     'default_value' => 'filesystem',
     'value_type'    => Enum['filesystem', 'lvm'],
-  }
+  })
 
   physical_volume { $blockdevice:
     ensure    => present,

--- a/manifests/nova/compute/disk.pp
+++ b/manifests/nova/compute/disk.pp
@@ -5,6 +5,11 @@ class ntnuopenstack::nova::compute::disk {
     'value_type' => String,
   })
 
+  $type = lookup('ntnuopenstack::compute::disk::type', {
+    'default_value' => 'filesystem',
+    'value_type'    => Enum['filesystem', 'lvm'],
+  }
+
   physical_volume { $blockdevice:
     ensure    => present,
     unless_vg => 'novacompute',
@@ -16,22 +21,33 @@ class ntnuopenstack::nova::compute::disk {
     physical_volumes => $blockdevice,
   }
 
-  logical_volume { 'ephemeral':
-    ensure       => present,
-    volume_group => 'novacompute',
-    size         => undef,          #undef means "all available space"
-  }
+  if($type == 'filesystem') {
+    logical_volume { 'ephemeral':
+      ensure       => present,
+      volume_group => 'novacompute',
+      size         => undef,          #undef means "all available space"
+    }
 
-  filesystem { '/dev/novacompute/ephemeral':
-    ensure  => present,
-    fs_type => 'ext4',
-  }
+    filesystem { '/dev/novacompute/ephemeral':
+      ensure  => present,
+      fs_type => 'ext4',
+    }
 
-  mount { '/var/lib/nova/instances':
-    ensure  => 'mounted',
-    device  => '/dev/novacompute/ephemeral',
-    fstype  => 'ext4',
-    require => Filesystem['/dev/novacompute/ephemeral'],
+    mount { '/var/lib/nova/instances':
+      ensure  => 'mounted',
+      device  => '/dev/novacompute/ephemeral',
+      fstype  => 'ext4',
+      require => Filesystem['/dev/novacompute/ephemeral'],
+    }
+
+    nova_config {
+      'libvirt/images_type': ensure => absent;
+    }
+  } else {
+    nova_config {
+      'libvirt/images_type':         value => 'lvm';
+      'libvirt/images_volume_group': value => 'novacompute';
+    }
   }
 
   file { '/var/lib/nova/instances':
@@ -41,7 +57,4 @@ class ntnuopenstack::nova::compute::disk {
     require => Mount['/var/lib/nova/instances'],
   }
 
-  nova_config {
-    'libvirt/images_type': ensure => absent;
-  }
 }

--- a/manifests/nova/compute/disk.pp
+++ b/manifests/nova/compute/disk.pp
@@ -40,6 +40,13 @@ class ntnuopenstack::nova::compute::disk {
       require => Filesystem['/dev/novacompute/ephemeral'],
     }
 
+    file { '/var/lib/nova/instances':
+      ensure  => 'directory',
+      group   => 'nova',
+      owner   => 'nova',
+      require => Mount['/var/lib/nova/instances'],
+    }
+
     nova_config {
       'libvirt/images_type': ensure => absent;
     }
@@ -48,13 +55,6 @@ class ntnuopenstack::nova::compute::disk {
       'libvirt/images_type':         value => 'lvm';
       'libvirt/images_volume_group': value => 'novacompute';
     }
-  }
-
-  file { '/var/lib/nova/instances':
-    ensure  => 'directory',
-    group   => 'nova',
-    owner   => 'nova',
-    require => Mount['/var/lib/nova/instances'],
   }
 
 }

--- a/manifests/nova/compute/libvirt.pp
+++ b/manifests/nova/compute/libvirt.pp
@@ -16,6 +16,14 @@ class ntnuopenstack::nova::compute::libvirt {
     'value_type'    => Array[String],
   })
 
+  # Allow to define a libvirt machine-type. For instance to allow VM's to have
+  # more than 1TB of memory.
+  # An example of a valid value: 'x86_64=pc-i440fx-focal-hpb'
+  $machine_type = lookup('ntnuopenstack::nova::libvirt::machine_type', {
+    'default_value' => undef,
+    'value_type'    => Variant[Undef, String],
+  })
+
   # A boolean to determine if we should allow nested virtualization
   $nova_nested_virt = lookup('ntnuopenstack::nova::nested_virtualization', {
     'default_value' => false,
@@ -48,6 +56,7 @@ class ntnuopenstack::nova::compute::libvirt {
   class { '::nova::compute::libvirt':
     cpu_model_extra_flags => $cpu_model_extra_flags,
     disk_cachemodes       => [ 'network=writeback' ],
+    hw_machine_type       => $machine_type,
     vncserver_listen      => $management_ip,
     *                     => $cpuconfig,
   }


### PR DESCRIPTION
Add support for using LVM for local-backed ephemeral disks, and allow settinging hw-machine-types to support instances with more than 1TB of RAM.

# New hiera-keys:
`ntnuopenstack::compute::disk::type`: Should be either "lvm" or "filesystem".
`ntnuopenstack::nova::libvirt::machine_type`: String defining a libvirt machine-type.