### PR TITLE
Traits

### DIFF
--- a/manifests/nova/compute/base.pp
+++ b/manifests/nova/compute/base.pp
@@ -1,6 +1,7 @@
 # Basic nova configuration for compute nodes.
 class ntnuopenstack::nova::compute::base {
   include ::ntnuopenstack::nova::common::base
+  include ::ntnuopenstack::nova::compute::provider
   include ::ntnuopenstack::nova::firewall::compute
   require ::ntnuopenstack::repo
 

--- a/manifests/nova/compute/provider.pp
+++ b/manifests/nova/compute/provider.pp
@@ -1,8 +1,8 @@
 # Configures the compute-nodes providers 
 class ntnuopenstack::nova::compute::provider {
   $providers = lookup('ntnuopenstack::nova::compute::providers', {
-    'default_value' => {},
-    'value_type'    => Hash[String,Hash], 
+    'default_value' => []
+    'value_type'    => Array[Hash], 
   })
 
   class {'::nova::compute::provider': 

--- a/manifests/nova/compute/provider.pp
+++ b/manifests/nova/compute/provider.pp
@@ -1,7 +1,7 @@
 # Configures the compute-nodes providers 
 class ntnuopenstack::nova::compute::provider {
   $providers = lookup('ntnuopenstack::nova::compute::providers', {
-    'default_value' => []
+    'default_value' => [],
     'value_type'    => Array[Hash], 
   })
 

--- a/manifests/nova/compute/provider.pp
+++ b/manifests/nova/compute/provider.pp
@@ -1,0 +1,11 @@
+# Configures the compute-nodes providers 
+class ntnuopenstack::nova::compute::provider {
+  $providers = lookup('ntnuopenstack::nova::compute::providers', {
+    'default_value' => {},
+    'value_type'    => Hash[String,Hash], 
+  })
+
+  class {'::nova::compute::provider': 
+    $custom_inventories => $providers
+  }
+}

--- a/manifests/nova/compute/provider.pp
+++ b/manifests/nova/compute/provider.pp
@@ -6,6 +6,6 @@ class ntnuopenstack::nova::compute::provider {
   })
 
   class {'::nova::compute::provider': 
-    $custom_inventories => $providers
+    custom_inventories => $providers,
   }
 }


### PR DESCRIPTION
Allow setting custom traits/inventories on the nodes providers.

Can for example be done by putting the following in hiera:

ntnuopenstack::nova::compute::providers:
 - name: 'gpu01.infra.skylow.iik.ntnu.no'
   traits: [ 'CUSTOM_COMPUTE_GPU' ]
 - name: 'gpu01.infra.skylow.iik.ntnu.no_pci_0000_3d_00_0'
   traits: [ 'CUSTOM_M10_8G' ]
 - name: 'gpu01.infra.skylow.iik.ntnu.no_pci_0000_3e_00_0'
   traits: [ 'CUSTOM_M10_8G' ]
 - name: 'gpu01.infra.skylow.iik.ntnu.no_pci_0000_3f_00_0'
   traits: [ 'CUSTOM_M10_8G' ]
 - name: 'gpu01.infra.skylow.iik.ntnu.no_pci_0000_40_00_0'
   traits: [ 'CUSTOM_M10_8G' ]