### PR TITLE
Proxylogging

### DIFF
--- a/manifests/horizon/base.pp
+++ b/manifests/horizon/base.pp
@@ -61,8 +61,10 @@ class ntnuopenstack::horizon::base {
     $extra_params = {
       access_log_format => 'forwarded',
     }
+    $secure_proxy_addr_header = 'HTTP_X_FORWARDED_FOR'
   } else {
     $extra_params = undef
+    $secure_proxy_addr_header = undef
   }
 
   # Determine which cacheservers to use
@@ -99,6 +101,7 @@ class ntnuopenstack::horizon::base {
     password_retrieve              => true,
     root_url                       => '/horizon',
     secret_key                     => $django_secret,
+    secure_proxy_addr_header       => $secure_proxy_addr_header,
     server_aliases                 => [$::fqdn, $server_name],
     servername                     => $server_name,
     session_timeout                => $session_timeout,

--- a/manifests/horizon/logging.pp
+++ b/manifests/horizon/logging.pp
@@ -7,4 +7,13 @@ class ntnuopenstack::horizon::logging {
   ntnuopenstack::common::logging { 'horizon':
     project => 'horizon',
   }
+
+  logrotate::rule { 'openstack-dashboard':
+    path         => '/var/log/horizon/*.log',
+    rotate       => 4,
+    rotate_every => 'week',
+    compress     => true,
+    copytruncate => true,
+    missingok    => true,
+  }
 }

--- a/manifests/horizon/logging.pp
+++ b/manifests/horizon/logging.pp
@@ -12,6 +12,7 @@ class ntnuopenstack::horizon::logging {
     path         => '/var/log/horizon/*.log',
     rotate       => 4,
     rotate_every => 'week',
+    minsize      => '100k',
     compress     => true,
     copytruncate => true,
     missingok    => true,


### PR DESCRIPTION
Tell horizon that it's running behind a reverse proxy, to ensure that the correct client IP is logged in the application logs. Also, ensure that the logrotate config actually works...