### PR TITLE
Scratchspace on Cinder controllers

### DIFF
--- a/manifests/cinder/ceph.pp
+++ b/manifests/cinder/ceph.pp
@@ -10,6 +10,7 @@ class ntnuopenstack::cinder::ceph {
 
   include ::cinder::deps
   require ::profile::ceph::client
+  include ::ntnuopenstack::cinder::ceph::tmpspace
 
   ceph_config {
     "client.${ceph_cinder_user}/key": value => $users["client.${ceph_cinder_user}"]['secret'];

--- a/manifests/cinder/ceph/tmpspace.pp
+++ b/manifests/cinder/ceph/tmpspace.pp
@@ -1,0 +1,44 @@
+# Creates a ceph image and mounts it so that cinder can store images there
+# during conversions.
+class ntnuopenstack::cinder::ceph::tmpspace {
+  $tmpsize = lookup('ntnuopenstack::cinder::tmpspace::gigabytes', {
+    'default_value' => 1000,
+    'value_type'    => Integer,
+  })
+
+  include ::cinder::deps
+  require ::profile::ceph::client
+
+  $megabytes = 1024 * $tmpsize
+  $imagename = "rbd/cinder-tmp-${::hostname}"
+  exec { 'Create RBD tmpspace':
+    command => "/usr/bin/rbd create --size ${megabytes} ${imagename}",
+    unless  => "/usr/bin/rbd info ${imagename}",
+  }
+
+  ::profile::ceph::rbdmap { 'Cinder-tmpspace':
+    image   => $imagename,
+    keyring => '/etc/ceph/ceph.client.admin.keyring',
+    user    => 'admin',
+    require => Exec['Create RBD tmpspace'],
+  }
+
+  exec { 'Format the tmpspace':
+    command => "/sbin/mkfs.ext4 /dev/rbd/${imagename}",
+    unless  => "/sbin/blkid -t TYPE=ext4 /dev/rbd/${imagename}",
+    require => Profile::Ceph::Rbdmap['Cinder-tmpspace'],
+  }
+
+  mount { '/var/lib/cinder/conversion':
+    ensure  => 'mounted',
+    device  => "/dev/rbd/${imagename}",
+    require => Exec['Format the tmpspace'],
+  }
+
+  file { '/var/lib/cinder/conversion':
+    ensure => directory,
+    group  => 'cinder',
+    owner  => 'cinder',
+    mode   => '0750',
+  }
+}

--- a/manifests/cinder/ceph/tmpspace.pp
+++ b/manifests/cinder/ceph/tmpspace.pp
@@ -26,16 +26,16 @@ class ntnuopenstack::cinder::ceph::tmpspace {
   exec { 'Format the tmpspace':
     command => "/sbin/mkfs.ext4 /dev/rbd/${imagename}",
     unless  => "/sbin/blkid -t TYPE=ext4 /dev/rbd/${imagename}",
-    require => Profile::Ceph::Rbdmap['Cinder-tmpspace'],
+    require => [
+      Profile::Ceph::Rbdmap['Cinder-tmpspace'],
+      Service['rbdmap'],
+    ],
   }
 
   mount { '/var/lib/cinder/conversion':
     ensure  => 'mounted',
     device  => "/dev/rbd/${imagename}",
-    require => [
-      Exec['Format the tmpspace'],
-      Service['rbdmap'],
-    ],
+    require => Exec['Format the tmpspace'],
   }
 
   file { '/var/lib/cinder/conversion':

--- a/manifests/cinder/ceph/tmpspace.pp
+++ b/manifests/cinder/ceph/tmpspace.pp
@@ -32,7 +32,10 @@ class ntnuopenstack::cinder::ceph::tmpspace {
   mount { '/var/lib/cinder/conversion':
     ensure  => 'mounted',
     device  => "/dev/rbd/${imagename}",
-    require => Exec['Format the tmpspace'],
+    require => [
+      Exec['Format the tmpspace'],
+      Service['rbdmap'],
+    ],
   }
 
   file { '/var/lib/cinder/conversion':

--- a/manifests/cinder/ceph/tmpspace.pp
+++ b/manifests/cinder/ceph/tmpspace.pp
@@ -34,6 +34,7 @@ class ntnuopenstack::cinder::ceph::tmpspace {
 
   mount { '/var/lib/cinder/conversion':
     ensure  => 'mounted',
+    fstype  => 'ext4',
     device  => "/dev/rbd/${imagename}",
     require => Exec['Format the tmpspace'],
   }


### PR DESCRIPTION
The cinder-controllers are now getting a rbd-volume mounted to /var/lib/cinder/conversion to have a place to store volumes when they should be uploaded to glance, or when they should be converted.

### New hiera-keys

 - ´ntnuopenstack::cinder::tmpspace::gigabytes´: An integer defining how large the volume should be. Defaults to 1000 (1TB).