### PR TITLE
Cinderstorage - Regression

### DIFF
--- a/manifests/cinder/ceph/tmpspace.pp
+++ b/manifests/cinder/ceph/tmpspace.pp
@@ -35,7 +35,7 @@ class ntnuopenstack::cinder::ceph::tmpspace {
   mount { '/var/lib/cinder/conversion':
     ensure  => 'mounted',
     fstype  => 'ext4',
-    options => 'defaults,nobootwait',
+    options => 'defaults,nofail,x-systemd.device-timeout=1',
     device  => "/dev/rbd/${imagename}",
     require => Exec['Format the tmpspace'],
   }

--- a/manifests/cinder/ceph/tmpspace.pp
+++ b/manifests/cinder/ceph/tmpspace.pp
@@ -35,6 +35,7 @@ class ntnuopenstack::cinder::ceph::tmpspace {
   mount { '/var/lib/cinder/conversion':
     ensure  => 'mounted',
     fstype  => 'ext4',
+    options => 'nobootwait',
     device  => "/dev/rbd/${imagename}",
     require => Exec['Format the tmpspace'],
   }

--- a/manifests/cinder/ceph/tmpspace.pp
+++ b/manifests/cinder/ceph/tmpspace.pp
@@ -35,7 +35,7 @@ class ntnuopenstack::cinder::ceph::tmpspace {
   mount { '/var/lib/cinder/conversion':
     ensure  => 'mounted',
     fstype  => 'ext4',
-    options => 'nobootwait',
+    options => 'defaults,nobootwait',
     device  => "/dev/rbd/${imagename}",
     require => Exec['Format the tmpspace'],
   }


### PR DESCRIPTION
We need to allow booting when rbd-volumes are missing as they are not available during the boot-process.