### PR TITLE
Openstack designate + Multiregion fixes

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -13,6 +13,12 @@ ntnuopenstack::cinder::endpoint::internal: "%{alias('ntnuopenstack::endpoint::in
 ntnuopenstack::cinder::endpoint::public: "%{alias('ntnuopenstack::endpoint::public')}"
 ntnuopenstack::cinder::mysql::ip: "%{alias('ntnuopenstack::endpoint::admin::ipv4')}"
 
+ntnuopenstack::designate::api::port: "9001"
+ntnuopenstack::designate::endpoint::admin: "%{alias('ntnuopenstack::endpoint::admin')}"
+ntnuopenstack::designate::endpoint::internal: "%{alias('ntnuopenstack::endpoint::internal')}"
+ntnuopenstack::designate::endpoint::public: "%{alias('ntnuopenstack::endpoint::public')}"
+ntnuopenstack::designate::mysql::ip: "%{alias('ntnuopenstack::endpoint::admin::ipv4')}"
+
 ntnuopenstack::glance::db::sync: "%{alias('ntnuopenstack::db::sync')}"
 ntnuopenstack::glance::endpoint::admin: "%{alias('ntnuopenstack::endpoint::admin')}"
 ntnuopenstack::glance::endpoint::internal: "%{alias('ntnuopenstack::endpoint::internal')}"

--- a/files/sudo/designate_sudoers
+++ b/files/sudo/designate_sudoers
@@ -1,0 +1,3 @@
+Defaults:designate !requiretty
+
+designate ALL = (root) NOPASSWD: /usr/bin/designate-rootwrap /etc/designate/rootwrap.conf *

--- a/manifests/cinder/api.pp
+++ b/manifests/cinder/api.pp
@@ -10,6 +10,7 @@ class ntnuopenstack::cinder::api {
     'default_value' => 'Normal',
   })
 
+  include ::cinder::quota
   include ::ntnuopenstack::common::credfolder
   require ::ntnuopenstack::cinder::base
   contain ::ntnuopenstack::cinder::firewall::server

--- a/manifests/cinder/api.pp
+++ b/manifests/cinder/api.pp
@@ -37,6 +37,6 @@ class ntnuopenstack::cinder::api {
   }
 
   cinder_config {
-    'DEFAULT/use_default_quota_clas': value => false;
+    'DEFAULT/use_default_quota_class': value => false;
   }
 }

--- a/manifests/cinder/api.pp
+++ b/manifests/cinder/api.pp
@@ -35,4 +35,8 @@ class ntnuopenstack::cinder::api {
     ssl               => false,
     access_log_format => $logformat,
   }
+
+  cinder_config {
+    'DEFAULT/use_default_quota_clas': value => false;
+  }
 }

--- a/manifests/cinder/api.pp
+++ b/manifests/cinder/api.pp
@@ -10,6 +10,7 @@ class ntnuopenstack::cinder::api {
     'default_value' => 'Normal',
   })
 
+  include ::ntnuopenstack::common::credfolder
   require ::ntnuopenstack::cinder::base
   contain ::ntnuopenstack::cinder::firewall::server
   require ::ntnuopenstack::repo

--- a/manifests/common/credfolder.pp
+++ b/manifests/common/credfolder.pp
@@ -1,0 +1,11 @@
+# Creates the folders needed to store openstack-creds for puppet types.
+class ntnuopenstack::common::credfolder {
+  file { '/etc/openstack':
+    ensure => directory,
+  }
+
+  file { '/etc/openstack/puppet':
+    ensure  => directory,
+    require => File['/etc/openstack'],
+  }
+}

--- a/manifests/databases.pp
+++ b/manifests/databases.pp
@@ -1,7 +1,7 @@
 # Defines the databases used by openstack
 class ntnuopenstack::databases {
   $region = lookup('ntnuopenstack::region')
-  $services = lookup('ntnuopenstack::services', {
+  $servicedata = lookup('ntnuopenstack::services', {
     'value_type' => Hash[String, Hash],
   })
   $zabbixpw = lookup('ntnuopenstack::zabbix::database::password', {
@@ -15,7 +15,7 @@ class ntnuopenstack::databases {
   $services = ['barbican', 'cinder', 'glance', 'heat', 'keystone', 'magnum',
     'neutron', 'nova', 'octavia', 'placement', ]
   $services.each | $service | {
-    if($region in $services and $service in $services[$region]['services']) {
+    if($region in $servicedata and $service in $servicedata[$region]['services']) {
       include "::ntnuopenstack::${service}::database"
     }
   }

--- a/manifests/databases.pp
+++ b/manifests/databases.pp
@@ -20,7 +20,7 @@ class ntnuopenstack::databases {
   $mysqlrole = lookup('profile::mysql::serverrole', {
     'default_value' => 'combined',
     'value_type'    =>  Enum['combined', 'region', 'common']
-  }
+  })
 
   $services = $mysqlrole ? {
     'combined' => $services_region + $services_common,

--- a/manifests/databases.pp
+++ b/manifests/databases.pp
@@ -12,8 +12,13 @@ class ntnuopenstack::databases {
   # Create databases for the openstack-services needed in the current region.
   # What services that are needed is determined by which services have gotten
   # data in hiera.
-  $services = ['barbican', 'cinder', 'glance', 'heat', 'keystone', 'magnum',
-    'neutron', 'nova', 'octavia', 'placement', ]
+  $default_services = [ 'barbican', 'cinder', 'glance', 'heat', 'keystone', 
+    'magnum', 'neutron', 'nova', 'octavia', 'placement', ]
+  $services = lookup('ntnuopenstack::service::databases' {
+    'default_value' => $default_services,
+    'value_type'    => Array[String],
+  })
+
   $services.each | $service | {
     if($region in $servicedata and $service in $servicedata[$region]['services']) {
       include "::ntnuopenstack::${service}::database"

--- a/manifests/databases.pp
+++ b/manifests/databases.pp
@@ -12,7 +12,7 @@ class ntnuopenstack::databases {
   # Create databases for the openstack-services needed in the current region.
   # What services that are needed is determined by which services have gotten
   # data in hiera.
-  $default_services = [ 'barbican', 'cinder', 'glance', 'heat', 'keystone', 
+  $default_services = [ 'barbican', 'cinder', 'glance', 'heat',
     'magnum', 'neutron', 'nova', 'octavia', 'placement', ]
   $services = lookup('ntnuopenstack::service::databases', {
     'default_value' => $default_services,
@@ -23,6 +23,14 @@ class ntnuopenstack::databases {
     if($region in $servicedata and $service in $servicedata[$region]['services']) {
       include "::ntnuopenstack::${service}::database"
     }
+  }
+
+  $keystone = lookup('ntnuopenstack::mysql::keystone::create', {
+    'default_value' => false,
+    'value_type'    => Boolean,
+  })
+  if($keystone) {
+    include ntnuopenstack::keystone::database
   }
 
   # If we are monitoring this platform with zabbix, create a user with

--- a/manifests/databases.pp
+++ b/manifests/databases.pp
@@ -1,26 +1,27 @@
 # Defines the databases used by openstack
 class ntnuopenstack::databases {
+  $region = lookup('ntnuopenstack::region')
+  $services = lookup('ntnuopenstack::services', {
+    'value_type' => Hash[String, Hash],
+  })
   $zabbixpw = lookup('ntnuopenstack::zabbix::database::password', {
     'default_value' => undef,
     'value_type'    => Optional[String],
   })
 
   # Create databases for the openstack-services needed in the current region.
-  # What services that are needed is determined by which services have gotten a
-  # database password in hiera.
+  # What services that are needed is determined by which services have gotten
+  # data in hiera.
   $services = ['barbican', 'cinder', 'glance', 'heat', 'keystone', 'magnum',
     'neutron', 'nova', 'octavia', 'placement', ]
   $services.each | $service | {
-    $password = lookup("ntnuopenstack::${service}::mysql::password", {
-      'default_value' => undef,
-      'value_type'    => Optional[String],
-    })
-    if($password) {
+    if($region in $services and $service in $services[$region]['services']) {
       include "::ntnuopenstack::${service}::database"
     }
   }
 
-  # If we are monitoring this platform with zabbix, ensure 
+  # If we are monitoring this platform with zabbix, create a user with
+  # read-access to the databases for zabbix. 
   if($zabbixpw) {
     include ::ntnuopenstack::zabbix::database
   }

--- a/manifests/databases.pp
+++ b/manifests/databases.pp
@@ -22,11 +22,17 @@ class ntnuopenstack::databases {
     'value_type'    =>  Enum['combined', 'region', 'common']
   })
 
-  $services = $mysqlrole ? {
+  $services_default = $mysqlrole ? {
     'combined' => $services_region + $services_common,
     'region'   => $services_region,
     'common'   => $services_common,
   }
+
+  # Allow hiera to override the role-derived databases
+  $services = lookup('ntnuopenstack::service::databases', {
+    'default_value' => $services_default,
+    'value_type'    => Array[String],
+  })
 
   $services.each | $service | {
     if($region in $servicedata and $service in $servicedata[$region]['services']) {

--- a/manifests/databases.pp
+++ b/manifests/databases.pp
@@ -14,7 +14,7 @@ class ntnuopenstack::databases {
   # data in hiera.
   $default_services = [ 'barbican', 'cinder', 'glance', 'heat', 'keystone', 
     'magnum', 'neutron', 'nova', 'octavia', 'placement', ]
-  $services = lookup('ntnuopenstack::service::databases' {
+  $services = lookup('ntnuopenstack::service::databases', {
     'default_value' => $default_services,
     'value_type'    => Array[String],
   })

--- a/manifests/designate/api.pp
+++ b/manifests/designate/api.pp
@@ -1,0 +1,11 @@
+# Configures a Designate API server, running most designate components
+class ntnuopenstack::designate::api {
+  require ::ntnuopenstack::repo
+
+  contain ::ntnuopenstack::designate::haproxy::backend
+  include ::ntnuopenstack::designate::sudo
+  require ::ntnuopenstack::designate::auth
+  require ::ntnuopenstack::designate::backend
+  require ::ntnuopenstack::designate::services
+
+}

--- a/manifests/designate/auth.pp
+++ b/manifests/designate/auth.pp
@@ -1,0 +1,31 @@
+# This class configures the keystone authentication for designate
+class ntnuopenstack::designate::auth {
+  $services = lookup('ntnuopenstack::services', {
+    'value_type' => Hash[String, Hash[String, Variant[Hash, String]]],
+  })
+
+  $cache_servers = lookup('profile::memcache::servers', {
+    'value_type' => Array[Stdlib::IP::Address],
+    'merge'      => 'unique',
+  })
+
+  $memcache = $cache_servers.map | $server | {
+    "${server}:11211"
+  }
+
+  $auth_url = lookup('ntnuopenstack::keystone::auth::url')
+  $www_authenticate_uri = lookup('ntnuopenstack::keystone::auth::uri')
+
+  $region = lookup('ntnuopenstack::region', String)
+
+  class { '::designate::keystone::authtoken':
+    auth_url             => $auth_url,
+    memcached_servers    => $memcache,
+    password             =>
+      $services[$region]['services']['designate']['keystone']['password'],
+    region_name          => $region,
+    username             =>
+      $services[$region]['services']['designate']['keystone']['username'],
+    www_authenticate_uri => $www_authenticate_uri, 
+  }
+}

--- a/manifests/designate/backend.pp
+++ b/manifests/designate/backend.pp
@@ -1,0 +1,39 @@
+# Designate interop with DNS Backend
+class ntnuopenstack::designate::backend {
+  $ns_servers = lookup('ntnuopenstack::designate::ns_servers', Array[Stdlib::IP::Address]);
+  $api_servers = lookup('ntnuopenstack::designate::api_servers', Array[Stdlib::IP::Address]);
+
+  class {'::designate::backend::bind9':
+    ns_records       => lookup('ntnuopenstack::designate::ns_records', Hash[Integer, String]),
+
+    rndc_config_file => '/etc/rndc.conf',
+    rndc_key_file    => '/etc/rndc.key',
+
+    mdns_hosts       => $api_servers,
+    bind9_hosts      => $ns_servers,
+    nameservers      => $ns_servers,
+    configure_bind   => false,
+  }
+
+  $rndc_algorithm = 'hmac-md5';
+  $rndc_name = 'rndc-key';
+  $rndc_secret = lookup('ntnuopenstack::designate::rndc_key', String);
+
+  file { '/etc/rndc.conf':
+    ensure  => file,
+    owner   => 'designate',
+    group   => 'designate',
+    mode    => '0644',
+    content => template('ntnuopenstack/designate/rndc-conf.erb'),
+    require => Package['designate-common'],
+  }
+
+  file { '/etc/rndc.key':
+    ensure  => file,
+    owner   => 'designate',
+    group   => 'designate',
+    mode    => '0640',
+    content => template('ntnuopenstack/designate/rndc-key.erb'),
+    require => Package['designate-common'],
+  }
+}

--- a/manifests/designate/database.pp
+++ b/manifests/designate/database.pp
@@ -1,0 +1,13 @@
+# Creates the databases for designate.
+class ntnuopenstack::designate::database {
+  $mysql_password = lookup('ntnuopenstack::designate::mysql::password', String)
+  $allowed_hosts = lookup('ntnuopenstack::mysql::allowed_hosts', {
+    'value_type' => Array[String],
+    'merge'      => 'first',
+  })
+
+  class {'::designate::db::mysql':
+    allowed_hosts => $allowed_hosts,
+    password      => $mysql_password,
+  }
+}

--- a/manifests/designate/dbconnection.pp
+++ b/manifests/designate/dbconnection.pp
@@ -1,0 +1,16 @@
+# Configures designate to use its database
+class ntnuopenstack::designate::dbconnection {
+  # Determine database-settings
+  $dbsync = lookup('ntnuopenstack::designate::mysql::sync', {
+    'default_value' => false,
+    'value_type'    => Boolean,
+  })
+  $mysql_pass = lookup('ntnuopenstack::designate::mysql::password', String)
+  $mysql_ip = lookup('ntnuopenstack::designate::mysql::ip', Stdlib::IP::Address)
+  $database_connection = "mysql+pymysql://designate:${mysql_pass}@${mysql_ip}/designate"
+
+  class { '::designate::db':
+    database_connection => $database_connection,
+    sync_db             => $dbsync,
+  }
+}

--- a/manifests/designate/endpoint.pp
+++ b/manifests/designate/endpoint.pp
@@ -1,0 +1,36 @@
+# Configures the endpoint and keystone user for designate
+define ntnuopenstack::designate::endpoint (
+  Stdlib::Httpurl $adminurl,
+  Stdlib::Httpurl $internalurl,
+  String          $password,
+  Stdlib::Httpurl $publicurl,
+  String          $region,
+  String          $username,
+) {
+  include ::designate::deps
+
+  Keystone::Resource::Service_identity["designate-${region}"]
+  -> Anchor['designate::service::end']
+
+  keystone::resource::service_identity { "designate-${region}":
+    configure_user      => true,
+    configure_user_role => true,
+    configure_endpoint  => true,
+    configure_service   => true,
+    service_type        => 'dns',
+    service_description => 'DNS as a Service',
+    service_name        => 'designate',
+    region              => $region,
+    auth_name           => $username,
+    password            => $password,
+    email               => 'designate@localhost',
+    tenant              => 'services',
+    roles               => ['admin'],
+    system_scope        => 'all',
+    system_roles        => [],
+    public_url          => "${publicurl}:9001",
+    admin_url           => "${adminurl}:9001",
+    internal_url        => "${internalurl}:9001",
+  }
+}
+

--- a/manifests/designate/firewall/api.pp
+++ b/manifests/designate/firewall/api.pp
@@ -1,0 +1,8 @@
+# Configures firewall rules for the designate API 
+class ntnuopenstack::designate::firewall::api {
+  $api_port = lookup('ntnuopenstack::designate::api::port')
+
+  ::profile::firewall::infra::all { 'designate API':
+    port     => $api_port,
+  }
+}

--- a/manifests/designate/firewall/dns.pp
+++ b/manifests/designate/firewall/dns.pp
@@ -1,0 +1,12 @@
+# Configures firewall rules for publishing nameservers
+class ntnuopenstack::designate::firewall::dns {
+  ::profile::firewall::global { 'designate publishing DNS server (TCP)':
+    transport_protocol => 'tcp',
+    port     => 53,
+  }
+
+  ::profile::firewall::global { 'designate publishing DNS server (UDP)':
+    transport_protocol => 'udp',
+    port     => 53,
+  }
+}

--- a/manifests/designate/firewall/haproxy.pp
+++ b/manifests/designate/firewall/haproxy.pp
@@ -1,0 +1,9 @@
+# Configures the firewall to accept incoming traffic to the designate API.
+class ntnuopenstack::designate::firewall::haproxy {
+  $port = lookup('ntnuopenstack::designate::api::port')
+
+  ::profile::firewall::custom { 'designate-api':
+    hiera_key => 'profile::networks::openstack::users',
+    port      => $port,
+  }
+}

--- a/manifests/designate/firewall/mdns.pp
+++ b/manifests/designate/firewall/mdns.pp
@@ -1,0 +1,7 @@
+# Configures firewall rules for mdns for designate::api
+class ntnuopenstack::designate::firewall::mdns {
+  ::profile::firewall::custom { 'designate mdns':
+    hiera_key => 'ntnuopenstack::designate::ns_servers',
+    port      => 5354,
+  }
+}

--- a/manifests/designate/firewall/rndc.pp
+++ b/manifests/designate/firewall/rndc.pp
@@ -1,0 +1,8 @@
+# Configures firewall rules for rndc to Designate NS servers
+class ntnuopenstack::designate::firewall::rndc {
+  ::profile::firewall::custom { 'designate rndc':
+    hiera_key => 'ntnuopenstack::designate::api_servers',
+    transport_protocol  => 'tcp',
+    port      => 953,
+  }
+}

--- a/manifests/designate/haproxy/backend.pp
+++ b/manifests/designate/haproxy/backend.pp
@@ -1,0 +1,22 @@
+# Exports a server-definition to be collected by the haproxy backends.
+class ntnuopenstack::designate::haproxy::backend {
+  $if = lookup('profile::interfaces::management', {
+    'default_value' => $::sl2['server']['primary_interface']['name'],
+    'value_type'    => String,
+  })
+  $port = lookup('ntnuopenstack::designate::api::port', String)
+
+  ::profile::services::haproxy::backend { 'DesignatePublic':
+    backend   => 'bk_designate_public',
+    port      => $port,
+    interface => $if,
+    options   => 'check inter 2000 rise 2 fall 5',
+  }
+
+  ::profile::services::haproxy::backend { 'DesignateAdmin':
+    backend   => 'bk_designate_admin',
+    port      => $port,
+    interface => $if,
+    options   => 'check inter 2000 rise 2 fall 5',
+  }
+}

--- a/manifests/designate/haproxy/management.pp
+++ b/manifests/designate/haproxy/management.pp
@@ -1,0 +1,33 @@
+# Configures the haproxy frontend for the public designate API
+class ntnuopenstack::designate::haproxy::management {
+  require ::profile::services::haproxy
+
+  include ::ntnuopenstack::designate::firewall::haproxy
+
+  $port = lookup('ntnuopenstack::designate::api::port')
+  $certificate = lookup('ntnuopenstack::endpoint::admin::cert', {
+    'default_value' => false,
+  })
+  if($certificate) {
+    $certfile = lookup('ntnuopenstack::endpoint::admin::cert::path', {
+      'value_type'    => String,
+      'default_value' => '/etc/ssl/private/haproxy.managementapi.pem'
+    })
+  } else {
+    $certfile = false
+  }
+
+  ::profile::services::haproxy::frontend { 'designate_admin':
+    profile   => 'management',
+    port      => $port,
+    certfile  => $certfile,
+    mode      => 'http',
+    bkoptions => {
+      'option'  => [
+        'tcplog',
+        'tcpka',
+        'httpchk',
+      ],
+    },
+  }
+}

--- a/manifests/designate/haproxy/services.pp
+++ b/manifests/designate/haproxy/services.pp
@@ -1,0 +1,33 @@
+# Configures the haproxy frontend for the public designate API
+class ntnuopenstack::designate::haproxy::services {
+  require ::profile::services::haproxy
+
+  include ::ntnuopenstack::designate::firewall::haproxy
+
+  $port = lookup('ntnuopenstack::designate::api::port')
+  $certificate = lookup('ntnuopenstack::endpoint::public::cert', {
+    'default_value' => false,
+  })
+  if($certificate) {
+    $certfile = lookup('ntnuopenstack::endpoint::public::cert::path', {
+      'value_type'    => String,
+      'default_value' => '/etc/ssl/private/haproxy.servicesapi.pem'
+    })
+  } else {
+    $certfile = false
+  }
+
+  ::profile::services::haproxy::frontend { 'designate_public':
+    profile   => 'services',
+    port      => $port,
+    certfile  => $certfile,
+    mode      => 'http',
+    bkoptions => {
+      'option'  => [
+        'tcplog',
+        'tcpka',
+        'httpchk',
+      ],
+    },
+  }
+}

--- a/manifests/designate/ns.pp
+++ b/manifests/designate/ns.pp
@@ -1,0 +1,42 @@
+# Designate publishing nameserver (NS) running bind9
+class ntnuopenstack::designate::ns {
+  require ::ntnuopenstack::repo
+  include ::ntnuopenstack::designate::firewall::dns
+  include ::ntnuopenstack::designate::firewall::rndc
+
+  $api_servers = lookup('ntnuopenstack::designate::api_servers', Array[Stdlib::IP::Address]);
+  $transfer_addresses = lookup('ntnuopenstack::designate::transfer_addresses', Array[String]);
+
+  $listen_on = 'any';
+  $listen_on_v6 = 'any';
+
+  class {'dns':
+    recursion          => 'no',
+    allow_recursion    => [],
+    listen_on_v6       => false, # Overwritten by additional_options
+    localzonepath      => 'unmanaged',
+    additional_options => {
+      'listen-on'         => "port 53 { ${listen_on}; }",
+      'listen-on-v6'      => "port 53 { ${listen_on_v6}; }",
+      'auth-nxdomain'     => 'no',
+      'allow-new-zones'   => 'yes',
+      'allow-notify'      => "{ ${join($api_servers, '; ')}; }",
+      'allow-update'      => "{ ${join($api_servers, '; ')}; }",
+      'allow-transfer'    => "{ ${join($api_servers + $transfer_addresses, '; ')}; }",
+
+      # https://docs.openstack.org/designate/latest/admin/production-guidelines.html#bind9-mitigation
+      'minimal-responses' => 'yes',
+    },
+    controls           => {
+      '*' => {
+        'port'              => 953,
+        'allowed_addresses' => $api_servers,
+        'keys'              => ['designate-rndc-key'],
+      }
+    },
+  }
+
+  dns::key {'designate-rndc-key':
+    secret   => lookup('ntnuopenstack::designate::rndc_key', String),
+  }
+}

--- a/manifests/designate/ns.pp
+++ b/manifests/designate/ns.pp
@@ -6,6 +6,12 @@ class ntnuopenstack::designate::ns {
 
   $api_servers = lookup('ntnuopenstack::designate::api_servers', Array[Stdlib::IP::Address]);
   $transfer_addresses = lookup('ntnuopenstack::designate::transfer_addresses', Array[String]);
+  $infra_all = lookup('profile::networks::infra::all', {
+    'value_type'   => Array[String],
+    'default_value' => [],
+  });
+
+  $allow_transfer = join($api_servers + $transfer_addresses + $infra_all, '; ');
 
   $listen_on = 'any';
   $listen_on_v6 = 'any';
@@ -22,7 +28,7 @@ class ntnuopenstack::designate::ns {
       'allow-new-zones'   => 'yes',
       'allow-notify'      => "{ ${join($api_servers, '; ')}; }",
       'allow-update'      => "{ ${join($api_servers, '; ')}; }",
-      'allow-transfer'    => "{ ${join($api_servers + $transfer_addresses, '; ')}; }",
+      'allow-transfer'    => "{ ${allow_transfer}; }",
 
       # https://docs.openstack.org/designate/latest/admin/production-guidelines.html#bind9-mitigation
       'minimal-responses' => 'yes',

--- a/manifests/designate/services.pp
+++ b/manifests/designate/services.pp
@@ -59,10 +59,7 @@ class ntnuopenstack::designate::services {
   class { 'designate::central':
     managed_resource_email     => lookup('ntnuopenstack::designate::hostmaster_email', Stdlib::Email),
     # Id of the "services" project that should own reverse zones
-    managed_resource_tenant_id => lookup('ntnuopenstack::designate::project_id', {
-      'value_type'    => String,
-      'default_value' => '00000000-0000-0000-0000-000000000000',
-    }),
+    managed_resource_tenant_id => lookup('ntnuopenstack::designate::project_id', String),
   }
 
   # designate-client

--- a/manifests/designate/services.pp
+++ b/manifests/designate/services.pp
@@ -52,7 +52,6 @@ class ntnuopenstack::designate::services {
 
   class { '::designate::wsgi::apache':
     access_log_format => 'forwarded',
-    workers           => 2,
     port              => Integer($api_port),
   }
 
@@ -76,16 +75,13 @@ class ntnuopenstack::designate::services {
   include ::ntnuopenstack::designate::firewall::mdns
   class { 'designate::mdns':
     listen  =>  '0.0.0.0:5354',
-    workers => 2,
   }
 
   # designate-producer
   class { 'designate::producer':
-    workers => 2,
   }
 
   # designate-worker
   class { 'designate::worker':
-    workers => 2,
   }
 }

--- a/manifests/designate/services.pp
+++ b/manifests/designate/services.pp
@@ -1,0 +1,91 @@
+# Configures the basic requirements for designate and the designate-services
+class ntnuopenstack::designate::services {
+  require ::ntnuopenstack::designate::dbconnection
+  include ::ntnuopenstack::designate::firewall::api
+
+  # Common / base configuration
+  $rabbitservers = lookup('profile::rabbitmq::servers', {
+    'value_type'    => Variant[Array[String], Boolean],
+    'default_value' => false,
+  })
+
+  if ($rabbitservers) {
+    $ha_transport_conf = {
+      rabbit_ha_queues    => true,
+      amqp_durable_queues => true,
+    }
+  } else {
+    $ha_transport_conf = {}
+  }
+
+  $transport_url = lookup('ntnuopenstack::transport::url')
+
+  class { '::designate':
+    default_transport_url => $transport_url,
+    *                     => $ha_transport_conf,
+  }
+
+  # Coordination
+  $zookeeper_servers = lookup('profile::zookeeper::servers', {
+    'value_type'    => Hash[String, Stdlib::IP::Address::Nosubnet],
+  })
+  $zookeeper_urls = values($zookeeper_servers).map | $server | {
+    "${server}:2181"
+  }
+  class { '::designate::coordination':
+    backend_url => "'zookeeper://${join($zookeeper_urls, ',')}'",
+  }
+  # Until we update to >= https://review.opendev.org/c/openstack/puppet-oslo/+/917759
+  ensure_packages('python3-kazoo', {
+    'ensure' => 'present'
+  })
+
+  # designate-api
+  $api_port = lookup('ntnuopenstack::designate::api::port')
+
+  class { '::designate::api':
+    auth_strategy    => 'keystone',
+    enable_api_v2    => true,
+    enable_api_admin => true,
+    service_name     => 'httpd',
+  }
+
+  class { '::designate::wsgi::apache':
+    access_log_format => 'forwarded',
+    workers           => 2,
+    port              => Integer($api_port),
+  }
+
+  # designate-central
+  class { 'designate::central':
+    managed_resource_email     => lookup('ntnuopenstack::designate::hostmaster_email', Stdlib::Email),
+    # Id of the "services" project that should own reverse zones
+    managed_resource_tenant_id => lookup('ntnuopenstack::designate::project_id', {
+      'value_type'    => String,
+      'default_value' => '00000000-0000-0000-0000-000000000000',
+    }),
+  }
+
+  # designate-client
+  include designate::client
+  ensure_packages('bind9-utils', {
+    'ensure' => 'present'
+  })
+
+  # designate-mdns
+  include ::ntnuopenstack::designate::firewall::mdns
+  class { 'designate::mdns':
+    listen  =>  '0.0.0.0:5354',
+    workers => 2,
+  }
+
+  # designate-producer
+  class { 'designate::producer':
+    workers => 2,
+  }
+
+  # designate-worker
+  class { 'designate::worker':
+    workers => 2,
+  }
+}

--- a/manifests/designate/sudo.pp
+++ b/manifests/designate/sudo.pp
@@ -1,0 +1,20 @@
+# This class configures sudo for designate
+class ntnuopenstack::designate::sudo {
+  # if purge::unmanaged is true we purge all files in sudoers.d that is not 
+  # managed by puppet. In this case we need to distribute «a» version of the
+  # sudo-config for openstack-services to work. It is though better to use the
+  # packaged version, so if the purge::unmanaged flag is set to false we will
+  # not delete the packed version.
+  $purge = lookup('profile::baseconfig::sudo::purge::unmanaged', {
+    'default_value' => true,
+    'value_type'    => Boolean,
+  })
+
+  if($purge) {
+    sudo::conf { 'designate_sudoers':
+      ensure         => 'present',
+      source         => 'puppet:///modules/ntnuopenstack/sudo/designate_sudoers',
+      sudo_file_name => 'designate_sudoers',
+    }
+  }
+}

--- a/manifests/horizon/base.pp
+++ b/manifests/horizon/base.pp
@@ -102,6 +102,7 @@ class ntnuopenstack::horizon::base {
     },
     password_retrieve              => true,
     root_url                       => '/horizon',
+    secure_cookies                 => $haproxy,
     secret_key                     => $django_secret,
     secure_proxy_addr_header       => $secure_proxy_addr_header,
     server_aliases                 => [$::fqdn, $server_name] + $aliases,

--- a/manifests/horizon/base.pp
+++ b/manifests/horizon/base.pp
@@ -8,6 +8,10 @@ class ntnuopenstack::horizon::base {
 
   # Horizon settings
   $server_name = lookup('ntnuopenstack::horizon::server_name')
+  $aliases = lookup('ntnuopenstack::horizon::server_aliases', {
+    'default_value' => [],
+    'value_type'    => Array[String],
+  })
   $django_secret = lookup('ntnuopenstack::horizon::django_secret')
   $ldap_name = lookup('ntnuopenstack::keystone::ldap_backend::name')
   $description = lookup('ntnuopenstack::horizon::ldap::description', {
@@ -79,7 +83,7 @@ class ntnuopenstack::horizon::base {
   }
 
   class { '::horizon':
-    allowed_hosts                  => [$::fqdn, $server_name],
+    allowed_hosts                  => [$::fqdn, $server_name] + $aliases,
     default_theme                  => 'default',
     enable_secure_proxy_ssl_header => $haproxy,
     help_url                       => $help_url,
@@ -100,7 +104,7 @@ class ntnuopenstack::horizon::base {
     root_url                       => '/horizon',
     secret_key                     => $django_secret,
     secure_proxy_addr_header       => $secure_proxy_addr_header,
-    server_aliases                 => [$::fqdn, $server_name],
+    server_aliases                 => [$::fqdn, $server_name] + $aliases,
     servername                     => $server_name,
     session_timeout                => $session_timeout,
     timezone                       => $timezone,

--- a/manifests/horizon/haproxy/backend.pp
+++ b/manifests/horizon/haproxy/backend.pp
@@ -11,11 +11,27 @@ class ntnuopenstack::horizon::haproxy::backend {
     backendname => 'bk_horizon',
   }
 
+  $region_fallback = lookup('profile::region', {
+    'default_value' => undef,
+    'value_type'    => Optional[String],
+  })
+  $region = lookup('profile::haproxy::region', {
+    'default_value' => $region_fallback,
+    'value_type'    => Optional[String],
+  })
+
+  if($region) {
+    $tags = ["region-${region}"]
+  } else {
+    $tags = []
+  }
+
   @@haproxy::balancermember { "horizon-${::fqdn}":
     listening_service => 'bk_horizon',
     server_names      => $::hostname,
     ipaddresses       => $ip,
     ports             => '80',
     options           => 'check inter 2000 rise 2 fall 5',
+    tag               => $tags,
   }
 }

--- a/manifests/horizon/haproxy/frontend.pp
+++ b/manifests/horizon/haproxy/frontend.pp
@@ -30,13 +30,25 @@ class ntnuopenstack::horizon::haproxy::frontend {
       'default_value' => undef,
       'value_type'    => Optional[String],
     })
-    $region = lookup('profile::haproxy::region', {
-      'default_value' => $region_fallback,
-      'value_type'    => String,
+    $overrides = lookup('profile::haproxy::region::override', {
+      'default_value' => {},
+      'value_type'    => Hash[String, Array[String]],
     })
 
-    Haproxy::Balancermember <<| listening_service == 'bk_horizon' and
-        tag == "region-${region}" |>>
+    # If there is defined an override-list for a certain haproxy-backend, use
+    # that list as the list of regions to collect servers from.
+    if("bk_${name}" in $overrides) {
+      $regions = [] + $overrides['bk_horizon']
+
+    # Otherwise use the haproxy-servers region
+    } else {
+      $regions = [ $region_fallback ]
+    }
+
+    $regions.each | $region | {
+      Haproxy::Balancermember <<| listening_service == 'bk_horizon' and
+          tag == "region-${region}" |>>
+    }
   }
 
 }

--- a/manifests/horizon/plugins.pp
+++ b/manifests/horizon/plugins.pp
@@ -17,5 +17,8 @@ class ntnuopenstack::horizon::plugins {
         'tag'    => ['horizon-package']
       })
     }
+    if('designate' in $data['services']) {
+      include ::horizon::dashboards::designate
+    }
   }
 }

--- a/manifests/keystone/endpoint.pp
+++ b/manifests/keystone/endpoint.pp
@@ -76,6 +76,14 @@ class ntnuopenstack::keystone::endpoint {
       }
     }
 
+    if('designate' in $data['services']) {
+      ::ntnuopenstack::designate::endpoint { $region:
+        password => $data['services']['designate']['keystone']['password'],
+        username => $data['services']['designate']['keystone']['username'],
+        *        => $common
+      }
+    }
+
     if('glance' in $data['services']) {
       ::ntnuopenstack::glance::endpoint { $region:
         password => $data['services']['glance']['keystone']['password'],

--- a/manifests/keystone/endpoint.pp
+++ b/manifests/keystone/endpoint.pp
@@ -1,19 +1,18 @@
 # Configures the required endpoints in keystone
 class ntnuopenstack::keystone::endpoint {
-  $keystone_region = lookup('ntnuopenstack::keystone::region', String)
+  $keystone_region = lookup('ntnuopenstack::keystone::region', {
+    'default_value' => undef,
+    'value_type'    => Optional[String],
+  })
   $services = lookup('ntnuopenstack::services', {
     'value_type' => Hash[String, Hash[String, Variant[Hash, String]]],
   })
 
   include ::ntnuopenstack::keystone::bootstrap
 
-  $keystone_admin = $services[$keystone_region]['url']['admin']
-  $keystone_internal = $services[$keystone_region]['url']['internal']
-  $keystone_public = $services[$keystone_region]['url']['public']
-
   # Check if any of the regions contains heat; and in that case create the heat
   # domain and roles.
-  $heats = $services.map | $region, $data | { 
+  $heats = $services.map | $region, $data | {
     $exists = 'heat' in $data['services']
     $exists
   }
@@ -36,6 +35,16 @@ class ntnuopenstack::keystone::endpoint {
       internalurl => $data['url']['internal'],
       publicurl   => $data['url']['public'],
       region      => $region,
+    }
+
+    if($keystone_region) {
+      $keystone_admin = $services[$keystone_region]['url']['admin']
+      $keystone_internal = $services[$keystone_region]['url']['internal']
+      $keystone_public = $services[$keystone_region]['url']['public']
+    } else {
+      $keystone_admin = $data['url']['admin']
+      $keystone_internal = $data['url']['internal']
+      $keystone_public = $data['url']['public']
     }
 
     keystone::resource::service_identity { "keystone-${region}":

--- a/manifests/keystone/firewall/server.pp
+++ b/manifests/keystone/firewall/server.pp
@@ -2,7 +2,19 @@
 #  - We basicly only allow our management-network to use keystone, as the rest
 #    of the traffic will enter trough the loadbalancers.
 class ntnuopenstack::keystone::firewall::server {
-  ::profile::firewall::infra::region { 'Keystone-API':
-    port => 5000,
+  $common = lookup('ntnuopenstack::keystone::interregional', {
+    'default_value' => false,
+    'value_type'    => Boolean,
+  })
+
+  if($common) {
+    ::profile::firewall::infra::all { 'Keystone-API':
+      port => 5000,
+    }
+  } else {
+    ::profile::firewall::infra::region { 'Keystone-API':
+      port => 5000,
+    }
   }
+
 }

--- a/manifests/neutron/api.pp
+++ b/manifests/neutron/api.pp
@@ -11,16 +11,24 @@ class ntnuopenstack::neutron::api {
     'default_value' => true,
   })
 
+  $services = lookup('ntnuopenstack::services', {
+    'value_type' => Hash[String, Hash[String, Variant[Hash, String]]],
+  })
+  $region = lookup('ntnuopenstack::region', String)
+
   include ::neutron::quota
   require ::ntnuopenstack::neutron::auth
   require ::ntnuopenstack::neutron::base
   require ::ntnuopenstack::neutron::dbconnection
-  include ::ntnuopenstack::neutron::designate
   include ::ntnuopenstack::neutron::firewall::api
   include ::ntnuopenstack::neutron::haproxy::backend
   include ::ntnuopenstack::neutron::logging::api
   include ::ntnuopenstack::neutron::ml2::config
   include ::ntnuopenstack::neutron::rpc
+
+  if('designate' in $services[$region]['services']) {
+    include ::ntnuopenstack::neutron::designate
+  }
 
   # Install the neutron api
   class { '::neutron::server':

--- a/manifests/neutron/api.pp
+++ b/manifests/neutron/api.pp
@@ -15,6 +15,7 @@ class ntnuopenstack::neutron::api {
   require ::ntnuopenstack::neutron::auth
   require ::ntnuopenstack::neutron::base
   require ::ntnuopenstack::neutron::dbconnection
+  include ::ntnuopenstack::neutron::designate
   include ::ntnuopenstack::neutron::firewall::api
   include ::ntnuopenstack::neutron::haproxy::backend
   include ::ntnuopenstack::neutron::logging::api

--- a/manifests/neutron/api.pp
+++ b/manifests/neutron/api.pp
@@ -11,6 +11,7 @@ class ntnuopenstack::neutron::api {
     'default_value' => true,
   })
 
+  include ::neutron::quota
   require ::ntnuopenstack::neutron::auth
   require ::ntnuopenstack::neutron::base
   require ::ntnuopenstack::neutron::dbconnection

--- a/manifests/neutron/base.pp
+++ b/manifests/neutron/base.pp
@@ -18,7 +18,10 @@ class ntnuopenstack::neutron::base {
     'default_value' => false,
   })
 
-  $dns_domain = lookup('ntnuopenstack::designate::neutron_floatingip::domain', String)
+  $dns_domain = lookup('ntnuopenstack::neutron::dns::domain', {
+    'default_value' => 'openstack.local',
+    'value_type'    => String,
+  })
 
   require ::ntnuopenstack::repo
   include ::ntnuopenstack::neutron::sudo

--- a/manifests/neutron/base.pp
+++ b/manifests/neutron/base.pp
@@ -18,6 +18,8 @@ class ntnuopenstack::neutron::base {
     'default_value' => false,
   })
 
+  $dns_domain = lookup('ntnuopenstack::designate::neutron_floatingip::domain', String)
+
   require ::ntnuopenstack::repo
   include ::ntnuopenstack::neutron::sudo
 
@@ -36,6 +38,7 @@ class ntnuopenstack::neutron::base {
     dhcp_agents_per_network => 2,
     global_physnet_mtu      => $mtu,
     service_plugins         => $service_plugins,
+    dns_domain              => $dns_domain,
     *                       => $ha_transport_conf,
   }
 

--- a/manifests/neutron/designate.pp
+++ b/manifests/neutron/designate.pp
@@ -1,0 +1,28 @@
+# Installs and configures the designate DNS integration for neutron
+class ntnuopenstack::neutron::designate {
+  $services = lookup('ntnuopenstack::services', {
+    'value_type' => Hash[String, Hash[String, Variant[Hash, String]]],
+  })
+
+  $auth_url = lookup('ntnuopenstack::keystone::auth::url')
+  $region = lookup('ntnuopenstack::region', String)
+
+  $api_url = lookup('ntnuopenstack::designate::endpoint::public')
+  $designate_port = lookup('ntnuopenstack::designate::api::port')
+
+  class { '::neutron::designate':
+    url                       => "${api_url}:${designate_port}/v2",
+    auth_url                  => $auth_url,
+    password                  => 
+      $services[$region]['services']['neutron']['keystone']['password'],
+    username                  => 
+      $services[$region]['services']['neutron']['keystone']['username'],
+    project_name              => 'services',
+
+    allow_reverse_dns_lookup  => true,
+    ptr_zone_email            => lookup('ntnuopenstack::designate::hostmaster_email', Stdlib::Email),
+    ipv6_ptr_zone_prefix_size => 64,
+    ipv4_ptr_zone_prefix_size => 24,
+  }
+}
+

--- a/manifests/neutron/designate.pp
+++ b/manifests/neutron/designate.pp
@@ -7,7 +7,7 @@ class ntnuopenstack::neutron::designate {
   $auth_url = lookup('ntnuopenstack::keystone::auth::url')
   $region = lookup('ntnuopenstack::region', String)
 
-  $api_url = lookup('ntnuopenstack::designate::endpoint::public')
+  $api_url = $services[$region]['url']['internal'] 
   $designate_port = lookup('ntnuopenstack::designate::api::port')
 
   class { '::neutron::designate':

--- a/manifests/neutron/ml2/config.pp
+++ b/manifests/neutron/ml2/config.pp
@@ -16,7 +16,10 @@ class ntnuopenstack::neutron::ml2::config {
     "${key}:${mtu}"
   }
 
-  $extension_drivers = lookup('ntnuopenstack::neutron::ml2::extension_drivers', Array[String])
+  $extension_drivers = lookup('ntnuopenstack::neutron::ml2::extension_drivers', {
+    'value_type'    => Array[String],
+    'default_value' => ['port_security'],
+  })
 
   if($strategy == 'vlan') {
     class { '::neutron::plugins::ml2':

--- a/manifests/neutron/ml2/config.pp
+++ b/manifests/neutron/ml2/config.pp
@@ -16,9 +16,11 @@ class ntnuopenstack::neutron::ml2::config {
     "${key}:${mtu}"
   }
 
+  $extension_drivers = lookup('ntnuopenstack::neutron::ml2::extension_drivers', Array[String])
+
   if($strategy == 'vlan') {
     class { '::neutron::plugins::ml2':
-      extension_drivers     => ['port_security'],
+      extension_drivers     => $extension_drivers,
       mechanism_drivers     => ['openvswitch', 'l2population'],
       network_vlan_ranges   => ["physnet-vlan:${low}:${high}"],
       physical_network_mtus => $physnetmtu,
@@ -27,7 +29,7 @@ class ntnuopenstack::neutron::ml2::config {
     }
   } elsif($strategy == 'vxlan') {
     class { '::neutron::plugins::ml2':
-      extension_drivers     => ['port_security'],
+      extension_drivers     => $extension_drivers,
       mechanism_drivers     => ['openvswitch', 'l2population'],
       physical_network_mtus => $physnetmtu,
       tenant_network_types  => ['vxlan'],

--- a/templates/designate/rndc-conf.erb
+++ b/templates/designate/rndc-conf.erb
@@ -1,0 +1,12 @@
+include "/etc/rndc.key";
+options {
+        default-key "rndc-key";
+        default-server 127.0.0.1;
+        default-port 953;
+};
+
+<% @ns_servers.each do |server| -%>
+server <%= server %> {
+        key "rndc-key";
+};
+<% end -%>

--- a/templates/designate/rndc-key.erb
+++ b/templates/designate/rndc-key.erb
@@ -1,0 +1,4 @@
+key "<%= @rndc_name %>" {
+    algorithm <%= @rndc_algorithm %>;
+    secret "<%= @rndc_secret %>";
+};


### PR DESCRIPTION
This release contains changes needed to properly deploy multi-region to our production clouds, and all profiles needed to deploy openstack Designate.

# Changes

 - Openstack Designate profiles are created to provide DNSaaS to our clouds
 - We allow specifying nova/neutron/cinder default-quotas through hiera
 - New logic to specify which databases should be created on a certain mysql cluster; as the multiregion architecture uses several clusters. The logic is initially controlled by specifying a certain MySQL server role (combined, region, common) to control if it is the region-specific, the common or all databases that should be created on the server. For max flexibility it is also possible to manually define the databases as a list.
 - Allow horizon-servers to respond to alternative hostnames.
 - Tag horizon haproxy backends/frontends to allow collecting a subset of them at certain loadbalancers.
 - Allow exposing keystone to other regions infra-networks

# Mandatory Hiera-keys

There is a new mandatory-key:

 - `ntnuopenstack::neutron::ml2::extension_drivers`: Controlling which extension drivers should be added to neutron. List of strings, and should be at least ['port_security'] if designate is not installed. If designate is installed the extension_driver 'dns_domain_keywords' should be added as well

There are some new keys that is mandatory if designate is to be installed:

 - `ntnuopenstack::designate::ns_servers`: A list of IP-addresses. Its the management IP of all designate DNS servers.
 - `ntnuopenstack::designate::api_servers`: A list of IP-adresses for the management-interfaces of all designate API servers.
 - `ntnuopenstack::designate::ns_records`: A hash defining the service-endpoints for the designate DNS service. Typically points to the anycast addresses like so: `{ 1: 'ns1.example.com', 2: ns2.example.com}`
 - `ntnuopenstack::designate::rndc_key`: An RNDC-key used by designate to update the Bind servers.
 - `ntnuopenstack::designate::hostmaster_email`: The e-mail to be places in automatically managed DNS-zones (typically the reverse-zones).
 - `ntnuopenstack::designate::project_id`: Project ID where Designate should create automatic zones. Typically in the services project.
 - `ntnuopenstack::designate::transfer_addresses`: List of CIDRs for network where we allow full zone transfers from.
 - `ntnuopenstack::designate::mysql::password`: MySQL-password for designate
 - 

# Optional Hiera-keys

 - `profile::mysql::serverrole`: Controls which databases is created on a certain mysql cluster. Enum['combined', 'region', 'common'] - Defaults to combined.
 - `ntnuopenstack::service::databases`: A list of strings defining which services to create databases for.
 - `ntnuopenstack::mysql::keystone::create` - Should the keystone-database be created on the database server. Keystone wont fit together with all the other services as it is not listed in the `ntnuopenstack::services` construct, and is thus needing its own key.
 - `ntnuopenstack::designate::api::port`: Which port to publish the designate API at. Defaults to 9001.
- `ntnuopenstack::horizon::server_aliases`: List of alternative names that the horizon-servers should serve horizon for.
- `ntnuopenstack::keystone::interregional`: Boolean controlling if other regions infra-nets should be able to reach keystone. Defaults to false.
- `ntnuopenstack::neutron::dns::domain`: String overriding neutrons default DNS domain


Some of the new optional hiera-keys are relevant only if Designate is to be installed:

 - `ntnuopenstack::designate::mysql::sync`: Boolean controlling if the database-schema should automatically be updated. Defaults to false.
 - `ntnuopenstack::designate::mysql::ip`: The IP contacted by designate to reach its database. Defaults to the generic mysql IP.
 - ``: 

There is a bunch of new keys for setting default-quotas. All requires an integer:

 - `cinder::quota::quota_backups`
 - `cinder::quota::quota_gigabytes`
 - `cinder::quota::quota_snapshots`
 - `cinder::quota::quota_volumes`
 - `neutron::quota::quota_security_group`
 - `neutron::quota::quota_security_group_rule`
 - `neutron::quota::quota_network`
 - `neutron::quota::quota_port`
 - `neutron::quota::quota_subnet`
 - `neutron::quota::quota_router`
 - `neutron::quota::quota_floatingip`
 - `nova::quota::instances`
 - `nova::quota::cores`
 - `nova::quota::ram`

