### PR TITLE
Fix a configuration bug that prevents rebuild of instances booted from a volume

### DIFF
--- a/manifests/cinder/base.pp
+++ b/manifests/cinder/base.pp
@@ -34,18 +34,19 @@ class ntnuopenstack::cinder::base {
     default_transport_url => $transport_url,
     *                     => $ha_transport_conf,
   }
-  
+
   class { '::cinder::glance':
     glance_api_servers => "${api_internal}:9292",
   }
 
   class { '::cinder::nova':
-    auth_url     => $auth_url,
-    interface    => 'internal',
-    password     =>
+    auth_type   => 'password',
+    auth_url    => $auth_url,
+    interface   => 'internal',
+    password    =>
       $services[$region_name]['services']['nova']['keystone']['password'],
-    region_name  => $region_name,
-    username                =>
+    region_name => $region_name,
+    username    =>
       $services[$region_name]['services']['nova']['keystone']['username'],
   }
 }

--- a/manifests/nova/compute/base.pp
+++ b/manifests/nova/compute/base.pp
@@ -20,11 +20,20 @@ class ntnuopenstack::nova::compute::base {
     'value_type'    => String,
   })
 
+  $reimage_timeout_per_gb = lookup('ntnuopenstack::nova::compute::reimage_timeout_per_gb', {
+    'default_value' => 90,
+    'value_type'    => Integer,
+  })
+
   class { '::ntnuopenstack::nova::common::base':
     extra_options => {
       initial_cpu_allocation_ratio  => $cpu_allocation,
       initial_ram_allocation_ratio  => $ram_allocation,
       initial_disk_allocation_ratio => $disk_allocation,
     }
+  }
+
+  nova_config {
+    'DEFAULT/reimage_timeout_per_gb': value => $reimage_timeout_per_gb;
   }
 }


### PR DESCRIPTION
We need to explicitly tell cinder's novaclient that we try to authenticate with a password. Secondly, the default timeout for rebuilding in nova-compute is a little low for some environments. Allow us to override it.