### PR TITLE
Add mod_status in apache for horizon

### DIFF
--- a/manifests/horizon/base.pp
+++ b/manifests/horizon/base.pp
@@ -83,6 +83,8 @@ class ntnuopenstack::horizon::base {
     $memcache = {}
   }
 
+  include ::apache::mod::status
+
   class { '::horizon':
     allowed_hosts                  => [$::fqdn, $server_name] + $aliases,
     default_theme                  => 'default',


### PR DESCRIPTION
Should've done this in the 2024.1 work, when we added this to verything else. It slipped away...