### PR TITLE
Increase the number of VNC ports we allow traffic to

### DIFF
--- a/manifests/nova/firewall/compute.pp
+++ b/manifests/nova/firewall/compute.pp
@@ -10,6 +10,6 @@ class ntnuopenstack::nova::firewall::compute {
     port     => '49152-49215',
   }
   ::profile::firewall::infra::region { 'QEMU-VNC':
-    port     => '5900-5999',
+    port     => '5900-6500',
   }
 }

--- a/manifests/nova/firewall/compute.pp
+++ b/manifests/nova/firewall/compute.pp
@@ -10,6 +10,6 @@ class ntnuopenstack::nova::firewall::compute {
     port     => '49152-49215',
   }
   ::profile::firewall::infra::region { 'QEMU-VNC':
-    port     => '5900-6500',
+    port     => '5900-6100',
   }
 }


### PR DESCRIPTION
We have hosts with more than 100 concurrent VMs running. On these hosts, the console will fail on random hosts because iptables will only allow 100 different ports.