### PR TITLE
Puppet8 compitability

### DIFF
--- a/manifests/cinder/ceph/tmpspace.pp
+++ b/manifests/cinder/ceph/tmpspace.pp
@@ -10,7 +10,7 @@ class ntnuopenstack::cinder::ceph::tmpspace {
   require ::profile::ceph::client
 
   $megabytes = 1024 * $tmpsize
-  $imagename = "rbd/cinder-tmp-${::hostname}"
+  $imagename = "rbd/cinder-tmp-${::facts['networking']['hostname']}"
   exec { 'Create RBD tmpspace':
     command => "/usr/bin/rbd create --size ${megabytes} ${imagename}",
     unless  => "/usr/bin/rbd info ${imagename}",

--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -3,7 +3,7 @@ class ntnuopenstack::common {
 
   require ::ntnuopenstack::repo
 
-  case $::osfamily {
+  case $::facts['os']['family'] {
     'RedHat': {
       package { 'openstack-selinux':
         ensure  => 'present',

--- a/manifests/glance/api.pp
+++ b/manifests/glance/api.pp
@@ -62,7 +62,7 @@ class ntnuopenstack::glance::api {
     show_multiple_locations      => true,
     sync_db                      => $db_sync,
     use_keystone_limits          => $use_keystone_limits,
-    worker_self_reference_url    => "http://${::fqdn}:9292",
+    worker_self_reference_url    => "http://${::facts['networking']['fqdn']}:9292",
   }
 
   class { '::glance::wsgi::apache':

--- a/manifests/horizon/base.pp
+++ b/manifests/horizon/base.pp
@@ -98,8 +98,9 @@ class ntnuopenstack::horizon::base {
 
   include ::apache::mod::status
 
+  $names = [$::facts['networking']['fqdn'], $server_name] + $aliases
   class { '::horizon':
-    allowed_hosts                  => [$::fqdn, $server_name] + $aliases,
+    allowed_hosts                  => $names, 
     default_theme                  => 'default',
     enable_secure_proxy_ssl_header => $haproxy,
     help_url                       => $help_url,
@@ -121,7 +122,7 @@ class ntnuopenstack::horizon::base {
     secure_cookies                 => $haproxy,
     secret_key                     => $django_secret,
     secure_proxy_addr_header       => $secure_proxy_addr_header,
-    server_aliases                 => [$::fqdn, $server_name] + $aliases,
+    server_aliases                 => $names, 
     servername                     => $server_name,
     session_timeout                => $session_timeout,
     timezone                       => $timezone,

--- a/manifests/horizon/haproxy/backend.pp
+++ b/manifests/horizon/haproxy/backend.pp
@@ -6,7 +6,7 @@ class ntnuopenstack::horizon::haproxy::backend {
   })
   $ip = $::facts['networking']['interfaces'][$if]['ip']
 
-  profile::services::haproxy::tools::register { "Horizon-${::hostname}":
+  profile::services::haproxy::tools::register { "Horizon-${::facts['networking']['hostname']}":
     servername  => $::facts['networking']['hostname'],
     backendname => 'bk_horizon',
   }
@@ -26,7 +26,7 @@ class ntnuopenstack::horizon::haproxy::backend {
     $tags = []
   }
 
-  @@haproxy::balancermember { "horizon-${::fqdn}":
+  @@haproxy::balancermember { "horizon-${::facts['networking']['fqdn']}":
     listening_service => 'bk_horizon',
     server_names      => $::facts['networking']['hostname'],
     ipaddresses       => $ip,

--- a/manifests/horizon/haproxy/backend.pp
+++ b/manifests/horizon/haproxy/backend.pp
@@ -7,7 +7,7 @@ class ntnuopenstack::horizon::haproxy::backend {
   $ip = $::facts['networking']['interfaces'][$if]['ip']
 
   profile::services::haproxy::tools::register { "Horizon-${::hostname}":
-    servername  => $::hostname,
+    servername  => $::facts['networking']['hostname'],
     backendname => 'bk_horizon',
   }
 
@@ -28,7 +28,7 @@ class ntnuopenstack::horizon::haproxy::backend {
 
   @@haproxy::balancermember { "horizon-${::fqdn}":
     listening_service => 'bk_horizon',
-    server_names      => $::hostname,
+    server_names      => $::facts['networking']['hostname'],
     ipaddresses       => $ip,
     ports             => '80',
     options           => 'check inter 2000 rise 2 fall 5',

--- a/manifests/neutron/bgp/agent.pp
+++ b/manifests/neutron/bgp/agent.pp
@@ -36,7 +36,7 @@ define ntnuopenstack::neutron::bgp::agent (
     path    => $bgpconf,
     section => 'DEFAULT',
     setting => 'host',
-    value   => "${::hostname}-${name}",
+    value   => "${::facts['networking']['hostname']}-${name}",
     require => Package['neutron-bgp-dragent'],
     tag     => [
       'neutron-dragent-bgp-config',

--- a/manifests/nova/compute/id.pp
+++ b/manifests/nova/compute/id.pp
@@ -7,7 +7,7 @@ class ntnuopenstack::nova::compute::id {
     'value_type' => Hash[String, String],
   })
 
-  if(! ($::fqdn in $ids)) {
+  if(! ($::facts['networking']['fqdn'] in $ids)) {
     fail(join([
       "The hostname ${::fqdn} is missing in the",
       "'ntnuopenstack::nova::compute::ids' key in hiera",
@@ -16,7 +16,7 @@ class ntnuopenstack::nova::compute::id {
 
   file { '/var/lib/nova/compute_id':
     ensure  => 'file',
-    content => $ids[$::fqdn],
+    content => $ids[$::facts['networking']['fqdn']],
     group   => 'nova',
     owner   => 'nova',
     mode    => '0640',

--- a/manifests/nova/compute/id.pp
+++ b/manifests/nova/compute/id.pp
@@ -9,7 +9,7 @@ class ntnuopenstack::nova::compute::id {
 
   if(! ($::facts['networking']['fqdn'] in $ids)) {
     fail(join([
-      "The hostname ${::fqdn} is missing in the",
+      "The hostname ${::facts['networking']['fqdn']} is missing in the",
       "'ntnuopenstack::nova::compute::ids' key in hiera",
     ], ' '))
   }

--- a/manifests/nova/compute/service.pp
+++ b/manifests/nova/compute/service.pp
@@ -48,7 +48,7 @@ class ntnuopenstack::nova::compute::service {
   }
 
   # TODO: Why do we need this?
-  $pymysql_pkg = $::osfamily ? {
+  $pymysql_pkg = $::facts['os']['family'] ? {
     'RedHat' => 'python2-PyMySQL',
     'Debian' => 'python3-pymysql',
     default  => '',

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -3,11 +3,11 @@
 # when we run the default OpenStack version for the current Ubuntu Release
 # set 'openstack_extras::repo::debian::ubuntu::manage_uca: false' in hiera if needed
 class ntnuopenstack::repo {
-  if ($::osfamily == 'Debian' and $::operatingsystem == 'Ubuntu') {
+  if ($::facts['os']['name'] == 'Ubuntu') {
     class { '::openstack_extras::repo::debian::ubuntu':
       package_require => true,
     }
   } else {
-    fail("Operating system family ${::osfamily} is not supported.")
+    fail("Operating system family ${::facts['os']['name']} is not supported.")
   }
 }

--- a/manifests/swift/radosgw.pp
+++ b/manifests/swift/radosgw.pp
@@ -41,4 +41,18 @@ class ntnuopenstack::swift::radosgw {
   ceph_config {
     "client.radosgw.${hostname}/rgw_enable_usage_log": value => true; 
   }
+
+  ::logrotate::rule { 'ceph-common':
+    path          => '/var/log/ceph/*.log',
+    compress      => true,
+    maxsize       => '4G',
+    missingok     => true,
+    postrotate    => 'killall -q -1 ceph-mon ceph-mgr ceph-mds ceph-osd ceph-fuse radosgw rbd-mirror cephfs-mirror || pkill -1 -x "ceph-mon|ceph-mgr|ceph-mds|ceph-osd|ceph-fuse|radosgw|rbd-mirror|cephfs-mirror" || true',
+    rotate        => 14,
+    rotate_every  => 'day',
+    sharedscripts => true,
+    su            => true,
+    su_user       => 'root',
+    su_group      => 'ceph',
+  }
 }

--- a/manifests/swift/radosgw.pp
+++ b/manifests/swift/radosgw.pp
@@ -14,7 +14,7 @@ class ntnuopenstack::swift::radosgw {
   if('dnsname' in $services[$region]['services']['swift']) {
     $swiftname = $services[$region]['services']['swift']['dnsname']
   } else {
-    $swiftname = $::fqdn
+    $swiftname = $::facts['networking']['fqdn']
   }
 
   $hostname = $trusted['hostname']

--- a/metadata.json
+++ b/metadata.json
@@ -1,41 +1,46 @@
 {
   "name": "ntnusky-ntnuopenstack",
-  "version": "4.3.2",
+  "version": "vE.0.1",
   "author": "NTNU IIK",
   "summary": "Installs, configures, and manages openstack.",
   "license": "",
   "source": "https://github.com/ntnusky/ntnuopenstack",
   "project_page": "https://github.com/ntnusky/ntnuopenstack",
   "dependencies": [
-    { "name":"openstack/ceph","version_requirement":">= 2.4.0 < 3.0.0" },
-    { "name":"openstack/cinder","version_requirement":">= 12.4.0 < 13.0.0" },
-    { "name":"openstack/glance","version_requirement":">= 12.5.0 < 13.0.0" },
-    { "name":"openstack/heat","version_requirement":">= 12.4.0 < 13.0.0" },
-    { "name":"openstack/horizon","version_requirement":">= 13.1.0 < 14.0.0" },
-    { "name":"openstack/keystone","version_requirement":">= 12.4.0 < 13.0.0" },
-    { "name":"openstack/neutron","version_requirement":">= 12.4.0 < 13.0.0" },
-    { "name":"openstack/nova","version_requirement":">= 12.4.0 < 13.0.0" },
-    { "name":"openstack/openstack_extras","version_requirement":">= 12.4.0 < 13.0.0" },
-    { "name":"openstack/openstacklib","version_requirement":">= 12.4.0 < 13.0.0" },
-    { "name":"openstack/oslo","version_requirement":">= 12.4.0 < 13.0.0" },
-    { "name":"openstack/vswitch","version_requirement":">= 8.4.0 < 9.0.0" },
-    { "name":"puppetlabs/stdlib","version_requirement":">= 4.25.0 < 6.0.0" },
-    { "name":"puppetlabs/inifile","version_requirement":">= 1.5.0 < 2.0.0" },
-    { "name":"ntnusky/profile","version_requirement":">= 1.11.7 < 2.0.0 " }
+    { "name":"openstack/barbican","version_requirement":">= 26.0.0 < 27.0.0" },
+    { "name":"openstack/ceph","version_requirement":">= 7.0.0 < 8.0.0" },
+    { "name":"openstack/cinder","version_requirement":">= 26.0.0 < 27.0.0" },
+    { "name":"openstack/designate","version_requirement":">= 26.0.0 < 27.0.0" },
+    { "name":"openstack/glance","version_requirement":">= 26.0.0 < 27.0.0" },
+    { "name":"openstack/heat","version_requirement":">= 26..00 < 27.0.0" },
+    { "name":"openstack/horizon","version_requirement":">= 26.0.0 < 27.0.0" },
+    { "name":"openstack/keystone","version_requirement":">= 26.0.0 < 27.0.0" },
+    { "name":"openstack/magnum","version_requirement":">= 26.0.0 < 27.0.0" },
+    { "name":"openstack/neutron","version_requirement":">= 26.0.0 < 27.0.0" },
+    { "name":"openstack/nova","version_requirement":">= 26.0.0 < 27.0.0" },
+    { "name":"openstack/octavia","version_requirement":">= 26.0.0 < 27.0.0" },
+    { "name":"openstack/openstack_extras","version_requirement":">= 26.0.0 < 27.0.0" },
+    { "name":"openstack/openstacklib","version_requirement":">= 26.0.0 < 27.0.0" },
+    { "name":"openstack/oslo","version_requirement":">= 26.0.0 < 27.0.0" },
+    { "name":"openstack/placement","version_requirement":">= 26.0.0 < 27.0.0" },
+    { "name":"openstack/vswitch","version_requirement":">= 22.0.0 < 23.0.0" },
+    { "name":"puppetlabs/stdlib","version_requirement":">= 9.7.0 < 10.0.0" },
+    { "name":"puppetlabs/inifile","version_requirement":">= 6.2.0 < 7.0.0" },
+    { "name":"ntnusky/profile","version_requirement":">= 1.30.9 < 2.0.0 " }
   ],
-  "data_provider": "hiera",
   "operatingsystem_support": [
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "16.04"
+        "22.04",
+        "24.04"
       ]
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.8.0 < 6.0.0"
+      "version_requirement": ">= 7.0.0 < 9.0.0"
     }
   ],
   "description": "Configures puppet openstack"


### PR DESCRIPTION
# Changes

- Replace all legacy facts to make the code puppet8 compatible
- Various updates for puppet8 compatibility
- Add a size-limit for radosgw's logfiles before logrotate rotates and zip's them.

## New hiera-keys:

 - `profile::openvx::release`: Which openvox-release to conifigure apt-repositories for. Defaults to "openvox8".
 