### PR TITLE
Add options to set volume shredding settings.

### DIFF
--- a/manifests/nova/compute/disk/lvm.pp
+++ b/manifests/nova/compute/disk/lvm.pp
@@ -1,8 +1,19 @@
 # Configures nova to use LVM to store its ephemeral disks.
 class ntnuopenstack::nova::compute::disk::lvm {
+  $clear_method = lookup('ntnuopenstack::compute::disk::clear::method', {
+    'default_value' => 'zero',
+    'value_type'    => Enum['zero', 'shred', 'none'],
+  })
+  $clear_size = lookup('ntnuopenstack::compute::disk::clear::size', {
+    'default_value' => 0,
+    'value_type'    => Integer,
+  })
+
   require ntnuopenstack::nova::compute::disk
 
   nova_config {
     'libvirt/images_volume_group': value => 'novacompute';
+    'libvirt/volume_clear':        value => $clear_method;
+    'libvirt/volume_clear_size':   value => $clear_size;
   }
 }


### PR DESCRIPTION
# Changes

Allow setting configuration-options controlling how block-devices are deleted at VM termination.

## New hiera-keys

 - `ntnuopenstack::compute::disk::clear::method` - Which deletion-method to be used. Defaults to 'zero'. Valid values are 'zero', 'shred' and 'none'.
 - `ntnuopenstack::compute::disk::clear::size` - The amount of megabytes to delete. Defaults to 0, meaning the whole block device.
